### PR TITLE
fix(permissions): fixed permissions filters editing and displaying

### DIFF
--- a/src/views/core/permissions/Edit.vue
+++ b/src/views/core/permissions/Edit.vue
@@ -52,8 +52,8 @@
         <div class="field">
           <label class="label">Filters</label>
           <div class="control" v-if="permission.filters.length > 0">
-            <span  v-for="(filter, index) in permission.filters" v-bind:key="filter.field" class="tag is-info">
-              {{ filter.field }}
+            <span  v-for="(filter, index) in permission.filters" v-bind:key="filter" class="tag is-info">
+              {{ filter }}
               <button class="delete is-small" @click="deleteFilter(index)"></button>
             </span>
             <span v-if="permission.filters.length === 0" class="tag is-light">No filters set.</span>
@@ -134,7 +134,7 @@ export default {
       this.permission.filters.splice(index, 1)
     },
     addFilter () {
-      this.permission.filters.push({ field: this.tmpFilter })
+      this.permission.filters.push(this.tmpFilter)
       this.tmpFilter = ''
     }
   },

--- a/src/views/core/permissions/Single.vue
+++ b/src/views/core/permissions/Single.vue
@@ -24,7 +24,7 @@
                   <td v-if="permission.filters.length === 0"><i>Not set</i></td>
                   <td v-if="permission.filters.length > 0">
                     <ul>
-                      <li v-for="filter in permission.filters" v-bind:key="filter.field">{{ filter.field }}</li>
+                      <li v-for="filter in permission.filters" v-bind:key="filter">{{ filter }}</li>
                     </ul>
                   </td>
                 </tr>


### PR DESCRIPTION
in old core, permission filters were an array of objects with `id` and `field` fields, in the new core it's just an array of strings