### PR TITLE
feat(members): allow email change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             which node && node -v
       - run: npm install
       - run: mkdir -p ~/reports
-      - run: npm run lint -- --format junit > ~/reports/eslint.xml
+      - run: npx vue-cli-service --no-fix --format junit > ~/reports/eslint.xml
       - store_test_results:
           path: ~/reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             which node && node -v
       - run: npm install
       - run: mkdir -p ~/reports
-      - run: npm run lint -- --format junit --output-file ~/reports/eslint.xml
+      - run: npm run lint -- --format junit > ~/reports/eslint.xml
       - store_test_results:
           path: ~/reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             which node && node -v
       - run: npm install
       - run: mkdir -p ~/reports
-      - run: npx vue-cli-service --no-fix --format junit > ~/reports/eslint.xml
+      - run: npx vue-cli-service lint --no-fix --format junit > ~/reports/eslint.xml
       - store_test_results:
           path: ~/reports
       - store_artifacts:

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -42,6 +42,16 @@ module.exports = [
     }
   },
   {
+    name: 'oms.mail_change',
+    path: '/mail-change',
+    component: 'auth/MailChange',
+    meta: {
+      label: 'Change your email',
+      skipLazyLoad: true,
+      auth: true
+    }
+  },
+  {
     name: 'oms.password_reset',
     path: '/password_reset/',
     component: 'auth/PasswordReset',

--- a/src/views/auth/MailChange.vue
+++ b/src/views/auth/MailChange.vue
@@ -1,0 +1,67 @@
+<template>
+<div class="content has-text-centered confirm-block">
+  <div class="columns is-vcentered">
+    <div class="column is-6 is-offset-3">
+      <div class="box">
+        <form v-on:submit.prevent="confirmToken">
+          <div class="field">
+            <label class="label">Token</label>
+            <div class="control">
+              <input v-model="token" data-cy="token" required class="input" type="text" placeholder="Type the token you've received at your mailbox here.">
+            </div>
+             <p class="help is-danger" v-if="error">{{ error }}</p>
+          </div>
+
+          <hr />
+          <p class="control">
+            <button type="submit" class="button is-primary">Change your email</button>
+          </p>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+</template>
+
+<script>
+
+import { mapGetters } from 'vuex'
+
+export default {
+  name: 'MailChange',
+  data () {
+    return {
+      token: '',
+      error: ''
+    }
+  },
+  computed: mapGetters(['services']),
+  methods: {
+    confirmToken () {
+      this.error = ''
+
+      this.axios.post(this.services['core'] + '/confirm-email-change', { token: this.token }).then(() => {
+        this.$root.showSuccess('Your email is changed.')
+        return this.$router.push({ name: 'oms.members.view', params: { id: 'me' } })
+      }).catch((err) => {
+        if (err.response.status === 404) { // validation errors
+          return this.$root.showError('The token is invalid.')
+        }
+
+        this.$root.showError('Could not change email', err)
+      })
+    }
+  },
+  mounted () {
+    if (this.$route.query.token) {
+      this.token = this.$route.query.token
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.confirm-block {
+  width: 100%
+}
+</style>

--- a/src/views/core/members/Single.vue
+++ b/src/views/core/members/Single.vue
@@ -32,6 +32,13 @@
           </div>
 
           <div class="field is-grouped" v-if="can.edit">
+            <button class="button is-fullwidth is-warning" @click="askChangeEmail()">
+              <span>Change email</span>
+              <span class="icon"><font-awesome-icon icon="envelope" /></span>
+            </button>
+          </div>
+
+          <div class="field is-grouped" v-if="can.edit">
             <button class="button is-fullwidth is-warning" @click="editPrimaryBodyModal()">
               <span>Set primary body</span>
               <span class="icon"><font-awesome-icon icon="edit" /></span>
@@ -247,13 +254,30 @@ export default {
     toggleActive () {
       this.isSwitchingStatus = true
       this.axios.put(this.services['core'] + '/members/' + this.user.id + '/active', { active: !this.user.active }).then((response) => {
-        console.log('response', response)
         this.user.active = response.data.data.active
         this.$root.showSuccess('User is ' + (this.user.active ? 'activated.' : 'suspended.'))
         this.isSwitchingStatus = false
       }).catch((err) => {
         this.$root.showError('Error changing user status', err)
         this.isSwitchingStatus = false
+      })
+    },
+    askChangeEmail() {
+      this.$buefy.dialog.prompt({
+          message: 'Change email',
+          inputAttrs: {
+              type: 'email',
+              placeholder: 'Change email'
+          },
+          trapFocus: true,
+          onConfirm: (newEmail) => this.changeEmail(newEmail)
+      })
+    },
+    changeEmail(newEmail) {
+      this.axios.put(this.services['core'] + '/members/' + this.user.id + '/email', { new_email: newEmail }).then((response) => {
+        this.$root.showSuccess('An email change is triggered. Check your new inbox for a confirmation.')
+      }).catch((err) => {
+        this.$root.showError('Error changing user email', err)
       })
     },
     fetchUser () {

--- a/src/views/core/members/Single.vue
+++ b/src/views/core/members/Single.vue
@@ -262,19 +262,19 @@ export default {
         this.isSwitchingStatus = false
       })
     },
-    askChangeEmail() {
+    askChangeEmail () {
       this.$buefy.dialog.prompt({
-          message: 'Change email',
-          inputAttrs: {
-              type: 'email',
-              placeholder: 'Change email'
-          },
-          trapFocus: true,
-          onConfirm: (newEmail) => this.changeEmail(newEmail)
+        message: 'Change email',
+        inputAttrs: {
+          type: 'email',
+          placeholder: 'Change email'
+        },
+        trapFocus: true,
+        onConfirm: (newEmail) => this.changeEmail(newEmail)
       })
     },
-    changeEmail(newEmail) {
-      this.axios.put(this.services['core'] + '/members/' + this.user.id + '/email', { new_email: newEmail }).then((response) => {
+    changeEmail (newEmail) {
+      this.axios.put(this.services['core'] + '/members/' + this.user.id + '/email', { new_email: newEmail }).then(() => {
         this.$root.showSuccess('An email change is triggered. Check your new inbox for a confirmation.')
       }).catch((err) => {
         this.$root.showError('Error changing user email', err)


### PR DESCRIPTION
added new email change prompt and a page to confirm it (basically a copypaste of a token confirmation after logging in, but  auth-only).

How it works:
1) user asks for an email change
2) a letter is sent to a new inbox, with the token
3) user opens it, inputs a token, presses 'confirm',  voila, the email is confirmed and changed for a user.

If the token is not used for 2 days, it's deleted from the system, so no way to change the email to not-existing one.

https://github.com/AEGEE/core/pull/42 should be merged and deployed before though.