### PR TITLE
feat(members): add member to a body. Fixes MEMB-794

### DIFF
--- a/src/views/core/bodies/AddMemberModal.vue
+++ b/src/views/core/bodies/AddMemberModal.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title">Add member</p>
+      <button class="delete" aria-label="close" @click="$parent.close()"></button>
+    </header>
+    <section class="modal-card-body" style="height:200px;">
+      <div class="field has-addons">
+        <b-autocomplete
+          v-model="memberName"
+          :data="members"
+          field="title"
+          :loading="isLoadingMembers"
+          @input="fetchMembers"
+          :expanded="true"
+          @select="option => addMember(option)">
+
+          <template slot-scope="props">
+            <div class="media">
+              <div class="media-content">{{ props.option.first_name }} {{ props.option.last_name }}</div>
+            </div>
+          </template>
+          </b-autocomplete>
+      </div>
+    </section>
+    <footer class="modal-card-foot">
+      <button class="button" @click="$parent.close()">Cancel</button>
+    </footer>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AddBodyMemberModal',
+  props: ['body', 'services', 'showError', 'showSuccess'],
+  data () {
+    return {
+      isLoadingMembers: false,
+      memberName: '',
+      members: [],
+      token: null
+    }
+  },
+  methods: {
+    fetchMembers () {
+      this.isLoadingMembers = true
+      this.members = []
+
+      if (this.token) this.token.cancel()
+      this.token = this.axios.CancelToken.source()
+
+      this.axios.get(this.services['core'] + '/members', {
+        cancelToken: this.token.token,
+        params: { query: this.memberName }
+      }).then((response) => {
+        this.members = response.data.data
+        this.isLoadingMembers = false
+      }).catch((err) => {
+        if (this.axios.isCancel(err)) {
+          return
+        }
+
+        this.isLoadingMembers = false
+        this.showError('Could not fetch members', err)
+      })
+    },
+    addMember (member) {
+      this.axios.post(this.services['core'] + '/bodies/' + this.body.id + '/members', {
+        user_id: member.id
+      }).then(() => {
+        this.showSuccess('Member is added.')
+        this.$parent.close()
+      }).catch((err) => {
+        if (err.response.status === 422) {
+          this.showError('Could not add member: this person is already a member of this body.')
+        } else {
+          this.showError('Could not add member', err)
+        }
+      })
+    }
+  }
+}
+</script>

--- a/src/views/core/bodies/Single.vue
+++ b/src/views/core/bodies/Single.vue
@@ -51,6 +51,13 @@
             </a>
           </div>
 
+          <div class="field is-grouped" v-if="can.viewMembers && can.addMembers">
+            <a @click="openAddMemberModal()" :class="['button', 'is-fullwidth']">
+              <span class="field-icon icon"><font-awesome-icon :icon="['fas', 'user-plus']" /></span>
+              <span class="field-label">Add member</span>
+            </a>
+          </div>
+
           <div class="field is-grouped" v-if="can.updateBody">
             <router-link :to="{ name: 'oms.bodies.edit', params: { id: body.id } }" :class="['button', 'is-fullwidth', 'is-warning']">
               <span class="field-icon icon"><font-awesome-icon :icon="['fas', 'edit']" /></span>
@@ -149,13 +156,14 @@
       </article>
     </div>
 
-    <b-loading is-full-page="false" :active.sync="isLoading"></b-loading>
+    <b-loading :is-full-page="false" :active.sync="isLoading"></b-loading>
   </div>
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
 import AddBoundCircleModal from './AddBoundCircleModal'
+import AddMemberModal from './AddMemberModal'
 
 export default {
   name: 'SingleBody',
@@ -181,11 +189,13 @@ export default {
       permissions: [],
       can: {
         viewMembers: false,
+        viewMembersGlobal: false,
         viewJoinRequests: false,
         viewCampaigns: false,
         createBoundCircles: false,
         updateBody: false,
-        deleteBody: false
+        deleteBody: false,
+        addMembers: false
       }
     }
   },
@@ -193,6 +203,22 @@ export default {
     openAddCircleModal () {
       this.$buefy.modal.open({
         component: AddBoundCircleModal,
+        hasModalCard: true,
+        props: {
+          // When programmatically opening a modal, it doesn't have access to Vue instance
+          // and therefore store, services and notifications functions. That's why
+          // I'm passing them as props.
+          // More info: https://github.com/buefy/buefy/issues/55
+          body: this.body,
+          services: this.services,
+          showError: this.$root.showError,
+          showSuccess: this.$root.showSuccess
+        }
+      })
+    },
+    openAddMemberModal () {
+      this.$buefy.modal.open({
+        component: AddMemberModal,
         hasModalCard: true,
         props: {
           // When programmatically opening a modal, it doesn't have access to Vue instance
@@ -285,12 +311,13 @@ export default {
         return this.axios.get(this.services['core'] + '/bodies/' + this.$route.params.id + '/my_permissions').then((permissionsResponse) => {
           this.permissions = permissionsResponse.data.data
           this.can.viewMembers = this.permissions.some(permission => permission.combined.endsWith('view:member'))
+          this.can.viewMembersGlobal = this.permissions.some(permission => permission.combined.endsWith('global:view:member'))
           this.can.viewJoinRequests = this.permissions.some(permission => permission.combined.endsWith('view:join_request'))
           this.can.viewCampaigns = this.permissions.some(permission => permission.combined.endsWith('view:campaign'))
           this.can.createBoundCircles = this.permissions.some(permission => permission.combined.endsWith('create:bound_circle'))
           this.can.updateBody = this.permissions.some(permission => permission.combined.endsWith('update:body'))
           this.can.deleteBody = this.permissions.some(permission => permission.combined.endsWith('delete:body'))
-
+          this.can.addMembers = this.permissions.some(permission => permission.combined.endsWith('add_member:body'))
 
           this.isLoading = false
         })

--- a/src/views/core/bodies/Single.vue
+++ b/src/views/core/bodies/Single.vue
@@ -44,17 +44,17 @@
             </a>
           </div>
 
-          <div class="field is-grouped" v-if="can.createBoundCircles">
-            <a @click="openAddCircleModal()" :class="['button', 'is-fullwidth', 'is-warning']">
-              <span class="field-icon icon"><font-awesome-icon :icon="['fas', 'edit']" /></span>
-              <span class="field-label">Add bound circle</span>
-            </a>
-          </div>
-
           <div class="field is-grouped" v-if="can.viewMembers && can.addMembers">
             <a @click="openAddMemberModal()" :class="['button', 'is-fullwidth']">
               <span class="field-icon icon"><font-awesome-icon :icon="['fas', 'user-plus']" /></span>
               <span class="field-label">Add member</span>
+            </a>
+          </div>
+
+          <div class="field is-grouped" v-if="can.createBoundCircles">
+            <a @click="openAddCircleModal()" :class="['button', 'is-fullwidth', 'is-warning']">
+              <span class="field-icon icon"><font-awesome-icon :icon="['fas', 'edit']" /></span>
+              <span class="field-label">Add bound circle</span>
             </a>
           </div>
 


### PR DESCRIPTION
added a modal to add members to a body, added a button that is displayed if you have permissions to do so. It's only accessible if you can see members globally (`global:view:member`), so admins only.