### PR TITLE
fix(members): fixed members pagination when switching page

### DIFF
--- a/src/views/core/members/List.vue
+++ b/src/views/core/members/List.vue
@@ -104,7 +104,7 @@ export default {
       this.fetchData()
     },
     onPageChange (page) {
-      this.page = page
+      this.page = page - 1
       this.fetchData()
     },
     onSort (field, order) {


### PR DESCRIPTION
the b-table's pagination starts with 1 and not 0, need to respect this.