### PR TITLE
fix: different weird things with empty task descriptions

### DIFF
--- a/src/views/core/bodies/Single.vue
+++ b/src/views/core/bodies/Single.vue
@@ -97,7 +97,7 @@
                     <span v-html="$options.filters.markdown(body.description)"/>
                   </td>
                 </tr>
-                <tr v-if="body.task_description !== null">
+                <tr v-if="body.task_description !== null && body.task_description != ''">
                   <th>Task description</th>
                   <td>
                     <span v-html="$options.filters.markdown(body.task_description)"/>

--- a/src/views/statutory/PositionsList.vue
+++ b/src/views/statutory/PositionsList.vue
@@ -200,7 +200,7 @@ export default {
       return this.$route.params.prefix
     },
     taskDescription () {
-      if (!this.selectedPosition.body_id || !this.selectedPosition.task_description || this.selectedPosition.task_description == '') {
+      if (!this.selectedPosition.body_id || !this.selectedPosition.task_description || this.selectedPosition.task_description === '') {
         return 'A description for this position has not been set.'
       }
       const body = this.bodies.find(bod => bod.id === this.selectedPosition.body_id)

--- a/src/views/statutory/PositionsList.vue
+++ b/src/views/statutory/PositionsList.vue
@@ -200,7 +200,7 @@ export default {
       return this.$route.params.prefix
     },
     taskDescription () {
-      if (!this.selectedPosition.body_id) {
+      if (!this.selectedPosition.body_id || !this.selectedPosition.task_description || this.selectedPosition.task_description == '') {
         return 'A description for this position has not been set.'
       }
       const body = this.bodies.find(bod => bod.id === this.selectedPosition.body_id)


### PR DESCRIPTION
Should fix that nothing shows up when the task description is not set at an Agora position.
Also deletes the category from the body overview, if it was set in the past but now empty again