### PR TITLE
fix(bodies): fix task descriptions. Fixes HELP-1272

### DIFF
--- a/src/views/core/bodies/Single.vue
+++ b/src/views/core/bodies/Single.vue
@@ -97,7 +97,7 @@
                     <span v-html="$options.filters.markdown(body.description)"/>
                   </td>
                 </tr>
-                <tr v-if="body.task_description !== null && body.task_description != ''">
+                <tr v-if="body.task_description">
                   <th>Task description</th>
                   <td>
                     <span v-html="$options.filters.markdown(body.task_description)"/>

--- a/src/views/statutory/PositionsList.vue
+++ b/src/views/statutory/PositionsList.vue
@@ -200,9 +200,10 @@ export default {
       return this.$route.params.prefix
     },
     taskDescription () {
-      if (!this.selectedPosition.body_id || !this.selectedPosition.task_description || this.selectedPosition.task_description === '') {
+      if (!this.selectedPosition || !this.selectedPosition.body_id) {
         return 'A description for this position has not been set.'
       }
+
       const body = this.bodies.find(bod => bod.id === this.selectedPosition.body_id)
       return body.task_description
     }


### PR DESCRIPTION
should in theory fix https://myaegee.atlassian.net/browse/HELP-1272

selectedPosition doesn't have `task_description` field, as it's in the body, so it won't work I assume. works locally, not sure if it'll work on production, but should in theory.