### PR TITLE
chore: update docker compose to allow building on host

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -7,8 +7,7 @@ services:
             dockerfile: ./docker/Dockerfile
         image: aegee/frontend:dev
         volumes:
-            # uncomment the next line and rebuild/restart if you build frontend on host
-            # - ./${PATH_FRONTEND}/../dist:/usr/app/src/dist
+            - ./${PATH_FRONTEND}/../dist:/usr/app/src/dist
             - ./${PATH_FRONTEND}/../public:/usr/app/src/public
             - ./${PATH_FRONTEND}/../src:/usr/app/src/src
             - ./${PATH_FRONTEND}/../babel.config.js:/usr/app/src/babel.config.js


### PR DESCRIPTION
As discussed on Slack, the docker compose file should by default allow building on host