### PR TITLE
feat(ma-33): add disclaimer and other info to event creation

### DIFF
--- a/src/views/events/Apply.vue
+++ b/src/views/events/Apply.vue
@@ -92,7 +92,7 @@
                 <p class="help is-danger" v-if="errors.agreed_to_privacy_policy">{{ errors.agreed_to_privacy_policy.join(', ') }}</p>
               </div>
 
-              <div class="field notification is-info">
+              <div class="field notification is-warning">
                 <label class="label">COVID-19 warning</label>
                 <p>
                   Please respect all the local rules and be aware that they might differ from what you are used to. Always carry a mask, listen to organisers and stick to social distancing and other safety rules. Also, be aware that your event might get cancelled or have issues with mobility!

--- a/src/views/events/Apply.vue
+++ b/src/views/events/Apply.vue
@@ -92,6 +92,14 @@
                 <p class="help is-danger" v-if="errors.agreed_to_privacy_policy">{{ errors.agreed_to_privacy_policy.join(', ') }}</p>
               </div>
 
+              <div class="field notification is-info">
+                <label class="label">COVID-19 warning</label>
+                <p>
+                  Please respect all the local rules and be aware that they might differ from what you are used to. Always carry a mask, listen to organisers and stick to social distancing and other safety rules. Also, be aware that your event might get cancelled or have issues with mobility!
+                  The <a href="https://reopen.europa.eu/" target="_blank">Re-open EU</a> website may help you identifying legal obligations if you cross a border.
+                </p>
+              </div>
+
               <div class="field">
                 <button type="submit" class="button is-primary">
                   Save application!

--- a/src/views/events/Edit.vue
+++ b/src/views/events/Edit.vue
@@ -33,6 +33,16 @@
       </div>
 
       <form @submit.prevent="saveEvent()">
+        <div class="field notification is-warning">
+          <label class="label">COVID-19 restrictions</label>
+          <p>
+            Please follow the advice of local authorities for organising public events!
+          </p><p>
+            Take into account the social distancing requirements and make sure you don't exceed the number of people allowed in the same place. Also, cleaning and sanitary measures must be respected.
+          </p><p>
+            If it is needed, you are allowed to expel participants who don't follow the rules after clear instructions.
+          </p>
+        </div>
         <div class="notification is-info" v-if="!$route.params.id">
           <div class="content">
             <p>If you want to upload the image, please add it after creating the event by going to "Edit event" and uploading it there.</p>
@@ -127,6 +137,15 @@
             <input class="input" type="number" v-model="event.max_participants" min="0" @input="$root.nullifyIfEmpty(event, 'max_participants')"/>
           </div>
           <p class="help is-danger" v-if="errors.max_participants">{{ errors.max_participants.join(', ') }}</p>
+        </div>
+        <div class="field notification is-info">
+          <label class="label">Regarding water access</label>
+          <p>
+            Please make sure that the participants have access to a reasonable amount of water during the event.
+          </p>
+          <p>
+            Tip: Advise your participants to bring their own refillable water bottles and remind them throughout the event to refill them.
+          </p>
         </div>
 
         <div class="subtitle is-fullwidth has-text-centered">Event dates</div>

--- a/src/views/events/Edit.vue
+++ b/src/views/events/Edit.vue
@@ -139,7 +139,7 @@
           <p class="help is-danger" v-if="errors.max_participants">{{ errors.max_participants.join(', ') }}</p>
         </div>
         <div class="field notification is-info">
-          <label class="label">Regarding water access</label>
+          <label class="label" style="color: white">Regarding water access</label>
           <p>
             Please make sure that the participants have access to a reasonable amount of water during the event.
           </p>


### PR DESCRIPTION
EQAC wanted two extra disclaimers on the event page.
This PR adds a COVID warning for both participants and organizers, and an info for organizers to plan for water access.