### PR TITLE
fix(general): fail request if no access token

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -15,6 +15,13 @@ export default {
     }
 
     const fetchUser = async () => {
+      // Prevent the request from being done if no access token
+      // to avoid extra requests when somebody is accesing the page
+      // when being unauthorized.
+      if (!window.localStorage.getItem('access-token') && !window.localStorage.getItem('refresh-token')) {
+        throw new Error('Both access and refresh token are not present.')
+      }
+
       const result = await Vue.axios.get(services['core'] + '/members/me', {
         headers: { 'X-For-Auth': 'true' }
       })


### PR DESCRIPTION
failing all requests if no access/refresh tokens was too much (as there are requests that could be done unauthorized), so at least fetching the user is now not performed if no tokens are provided. This should reduce the number of requests to core when somebody is accessing my.aegee.eu while being unauthorized (before we tried to load the user information, now we are not even trying to if no tokens are provided)