### PR TITLE
fix(statutory): fix setting fee paid for members list. Fixes HELP-1305

### DIFF
--- a/src/views/statutory/ListMembersLists.vue
+++ b/src/views/statutory/ListMembersLists.vue
@@ -84,9 +84,11 @@ export default {
         message: 'Set fee paid',
         inputAttrs: {
           placeholder: 'Fee paid (in EUR)',
-          required: true
+          required: true,
+          type: 'number',
+          step: 0.001
         },
-        onConfirm: (newFee) => this.setFeePaid(newFee, memberslist)
+        onConfirm: (newFee) => this.setFeePaid(parseFloat(newFee), memberslist)
       })
     },
     setFeePaid (newFee, memberslist) {

--- a/src/views/statutory/ListMembersLists.vue
+++ b/src/views/statutory/ListMembersLists.vue
@@ -86,7 +86,7 @@ export default {
           placeholder: 'Fee paid (in EUR)',
           required: true,
           type: 'number',
-          step: 0.001
+          step: 0.01
         },
         onConfirm: (newFee) => this.setFeePaid(parseFloat(newFee), memberslist)
       })


### PR DESCRIPTION
apparently we send `fee_paid` as string and for whatever reason backend also returns it as string (it stores it properly though), so I've done 2 things: converting this value to a float and 2) updated the input so it'd only accept float values (so if you'll type `aaa`, it'll complain)