### PR TITLE
fix(events): Add help for placeholder budget link. Fixes HELP-1360

### DIFF
--- a/src/views/events/Edit.vue
+++ b/src/views/events/Edit.vue
@@ -521,6 +521,8 @@
             <p>
               You can omit specifying them when creating the event, but
               <strong> you won't be able to submit event to EQAC if these fields are not set.</strong>
+
+              For online events, you are able to use https://online-event.example.com/ as a placeholder for the budget.
             </p>
             <p>Please provide the link to Google spreadsheets for the event program and budget.</p>
             <p><a href="https://docs.google.com/spreadsheets/u/1/?ftv=1&tgif=d" target="_blank">


### PR DESCRIPTION
Since adding online events is not fully implemented in MyAEGEE, I've added some help for event organizers which do not have a budget since online events are free.