### PR TITLE
fix(statutory): edit application now only shows applicable bodies

### DIFF
--- a/src/views/statutory/EditApplication.vue
+++ b/src/views/statutory/EditApplication.vue
@@ -520,7 +520,7 @@ export default {
         // Fetching user to get his/her bodies
         return this.axios.get(this.services['core'] + '/members/' + this.application.user_id)
       }).then((user) => {
-        this.bodies = user.data.data.bodies
+        this.bodies = user.data.data.bodies.filter(body => this.can.apply_from_body[body.id])
         this.isLoading = false
       }).catch((err) => {
         this.isLoading = false


### PR DESCRIPTION
It was only changed with new applications in the [previous PR](https://github.com/AEGEE/frontend/pull/682), so now a quick fix for this when users edit their current application.