### PR TITLE
fix(events): only display events you are going to. Fixes HELP-1477

### DIFF
--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -165,7 +165,7 @@ export default {
     this.axios.get(this.services['events'] + '/mine/participating').then((eventsResponse) => {
       this.axios.get(this.services['statutory'] + '/mine').then((statutoryResponse) => {
         const input = eventsResponse.data.data.concat(statutoryResponse.data.data)
-        for (const event of input) {)
+        for (const event of input) {
           if (!event.applications[0].cancelled && event.applications[0].status != 'rejected') {
             if (moment().isSameOrBefore(event.starts)) {
               this.events.future.push(event)

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -166,7 +166,7 @@ export default {
       this.axios.get(this.services['statutory'] + '/mine').then((statutoryResponse) => {
         const input = eventsResponse.data.data.concat(statutoryResponse.data.data)
         for (const event of input) {
-          if (!event.applications[0].cancelled && event.applications[0].status != 'rejected') {
+          if (!event.applications[0].cancelled && event.applications[0].status !== 'rejected') {
             if (moment().isSameOrBefore(event.starts)) {
               this.events.future.push(event)
             } else {

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -165,11 +165,13 @@ export default {
     this.axios.get(this.services['events'] + '/mine/participating').then((eventsResponse) => {
       this.axios.get(this.services['statutory'] + '/mine').then((statutoryResponse) => {
         const input = eventsResponse.data.data.concat(statutoryResponse.data.data)
-        for (const event of input) {
-          if (moment().isSameOrBefore(event.starts)) {
-            this.events.future.push(event)
-          } else {
-            this.events.past.push(event)
+        for (const event of input) {)
+          if (!event.applications[0].cancelled && event.applications[0].status != 'rejected') {
+            if (moment().isSameOrBefore(event.starts)) {
+              this.events.future.push(event)
+            } else {
+              this.events.past.push(event)
+            }
           }
         }
         this.events.past.sort((e1, e2) => ((e1.starts < e2.starts) ? 1 : -1))


### PR DESCRIPTION
The events on the dashboard should now only be displayed if you have not cancelled them, and got accepted to that event. Needs to be merged together with two other PR's for the backend.

Fixes [HELP-1477](https://myaegee.atlassian.net/servicedesk/customer/portal/1/HELP-1477)