### PR TITLE
chore(deps): revert chart.js to 2.9.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4172,9 +4172,9 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.0.10.tgz",
-      "integrity": "sha512-DXFEhgSt5u22imTWbw8wfcVGB90nFJNcjUBtJI3zswJojzZ7yXpY4i2Va5RBRQRTtj00BfG0stbilAtKrKp35g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.1.0.tgz",
+      "integrity": "sha512-zr9kTlF3/84QE9XH765TwvG0ljysSrxEGPNL1prxpWS9fHD7Pa+58L7pgLQwmw4i1QIkhh9cANvY9l7uldvh5w==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.2.0",
@@ -4184,7 +4184,7 @@
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^5.0.0",
-        "npm": "^6.14.9",
+        "npm": "^7.0.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
         "registry-auth-token": "^4.0.0",
@@ -4306,9 +4306,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -7053,9 +7053,30 @@
       }
     },
     "chart.js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.0.1.tgz",
-      "integrity": "sha512-GR62zMZX8lRCr4Nq60aQ84QpsUYrpm9NWECR+Qu2pouzXqPI4zWHUF2MG/azXnBGn85cHR6tkv7cgY3lX5u9SA=="
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
+      "requires": {
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
+    "chartjs-color": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "requires": {
+        "chartjs-color-string": "^0.6.0",
+        "color-convert": "^1.9.3"
+      }
+    },
+    "chartjs-color-string": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "requires": {
+        "color-name": "^1.0.0"
+      }
     },
     "check-more-types": {
       "version": "2.24.0",
@@ -15314,144 +15335,227 @@
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
     },
     "npm": {
-      "version": "6.14.11",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.11.tgz",
-      "integrity": "sha512-1Zh7LjuIoEhIyjkBflSSGzfjuPQwDlghNloppjruOH5bmj9midT9qcNT0tRUZRR04shU9ekrxNy9+UTBrqeBpQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.8.0.tgz",
+      "integrity": "sha512-9AC3Dj9OUWaUdmTmEVttE/1MWkfF7+sAKPRo9tKEyjo49AXmHQBn+RC33M9dima91mEMqDIA71xyRm4VmhDipg==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.3.5",
+        "@npmcli/arborist": "^2.3.0",
+        "@npmcli/ci-detect": "^1.2.0",
+        "@npmcli/config": "^2.1.0",
+        "@npmcli/run-script": "^1.8.4",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
-        "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "bin-links": "^1.1.8",
-        "bluebird": "^3.5.5",
-        "byte-size": "^5.0.1",
-        "cacache": "^12.0.3",
-        "call-limit": "^1.1.1",
-        "chownr": "^1.1.4",
-        "ci-info": "^2.0.0",
+        "byte-size": "^7.0.1",
+        "cacache": "^15.0.6",
+        "chalk": "^4.1.0",
+        "chownr": "^2.0.0",
         "cli-columns": "^3.1.2",
-        "cli-table3": "^0.5.1",
-        "cmd-shim": "^3.0.3",
+        "cli-table3": "^0.6.0",
         "columnify": "~1.5.4",
-        "config-chain": "^1.1.12",
-        "debuglog": "*",
-        "detect-indent": "~5.0.0",
-        "detect-newline": "^2.1.0",
-        "dezalgo": "~1.0.3",
-        "editor": "~1.0.0",
-        "figgy-pudding": "^3.5.1",
-        "find-npm-prefix": "^1.0.2",
-        "fs-vacuum": "~1.2.10",
-        "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.3.1",
-        "glob": "^7.1.6",
-        "graceful-fs": "^4.2.4",
-        "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.8.8",
-        "iferr": "^1.0.2",
-        "imurmurhash": "*",
-        "infer-owner": "^1.0.4",
-        "inflight": "~1.0.6",
-        "inherits": "^2.0.4",
-        "ini": "^1.3.8",
-        "init-package-json": "^1.10.3",
-        "is-cidr": "^3.0.0",
-        "json-parse-better-errors": "^1.0.2",
-        "lazy-property": "~1.0.0",
-        "libcipm": "^4.0.8",
-        "libnpm": "^3.0.1",
-        "libnpmaccess": "^3.0.2",
-        "libnpmhook": "^5.0.3",
-        "libnpmorg": "^1.0.1",
-        "libnpmsearch": "^2.0.2",
-        "libnpmteam": "^1.0.2",
-        "libnpx": "^10.2.4",
-        "lock-verify": "^2.1.0",
-        "lockfile": "^1.0.4",
-        "lodash._baseindexof": "*",
-        "lodash._baseuniq": "~4.6.0",
-        "lodash._bindcallback": "*",
-        "lodash._cacheindexof": "*",
-        "lodash._createcache": "*",
-        "lodash._getnative": "*",
-        "lodash.clonedeep": "~4.5.0",
-        "lodash.restparam": "*",
-        "lodash.union": "~4.6.0",
-        "lodash.uniq": "~4.5.0",
-        "lodash.without": "~4.4.0",
-        "lru-cache": "^5.1.1",
-        "meant": "^1.0.2",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.5",
-        "move-concurrently": "^1.0.1",
-        "node-gyp": "^5.1.0",
-        "nopt": "^4.0.3",
-        "normalize-package-data": "^2.5.0",
-        "npm-audit-report": "^1.3.3",
-        "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "^3.0.2",
-        "npm-lifecycle": "^3.1.5",
-        "npm-package-arg": "^6.1.1",
-        "npm-packlist": "^1.4.8",
-        "npm-pick-manifest": "^3.0.2",
-        "npm-profile": "^4.0.4",
-        "npm-registry-fetch": "^4.0.7",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "hosted-git-info": "^4.0.2",
+        "ini": "^2.0.0",
+        "init-package-json": "^2.0.2",
+        "is-cidr": "^4.0.2",
+        "json-parse-even-better-errors": "^2.3.1",
+        "leven": "^3.1.0",
+        "libnpmaccess": "^4.0.1",
+        "libnpmdiff": "^2.0.4",
+        "libnpmfund": "^1.0.2",
+        "libnpmhook": "^6.0.1",
+        "libnpmorg": "^2.0.1",
+        "libnpmpack": "^2.0.1",
+        "libnpmpublish": "^4.0.0",
+        "libnpmsearch": "^3.1.0",
+        "libnpmteam": "^2.0.2",
+        "libnpmversion": "^1.1.0",
+        "make-fetch-happen": "^8.0.14",
+        "minipass": "^3.1.3",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "ms": "^2.1.2",
+        "node-gyp": "^7.1.2",
+        "nopt": "^5.0.0",
+        "npm-audit-report": "^2.1.4",
+        "npm-package-arg": "^8.1.2",
+        "npm-pick-manifest": "^6.1.1",
+        "npm-profile": "^5.0.2",
+        "npm-registry-fetch": "^9.0.0",
         "npm-user-validate": "^1.0.1",
         "npmlog": "~4.1.2",
-        "once": "~1.4.0",
         "opener": "^1.5.2",
-        "osenv": "^0.1.5",
-        "pacote": "^9.5.12",
-        "path-is-inside": "~1.0.2",
-        "promise-inflight": "~1.0.1",
+        "pacote": "^11.3.1",
+        "parse-conflict-json": "^1.1.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.8.2",
-        "qw": "~1.0.1",
         "read": "~1.0.7",
-        "read-cmd-shim": "^1.0.5",
-        "read-installed": "~4.0.3",
-        "read-package-json": "^2.1.1",
-        "read-package-tree": "^5.3.1",
-        "readable-stream": "^3.6.0",
+        "read-package-json": "^3.0.1",
+        "read-package-json-fast": "^2.0.2",
         "readdir-scoped-modules": "^1.1.0",
-        "request": "^2.88.0",
-        "retry": "^0.12.0",
-        "rimraf": "^2.7.1",
-        "safe-buffer": "^5.1.2",
-        "semver": "^5.7.1",
-        "sha": "^3.0.0",
-        "slide": "~1.1.6",
-        "sorted-object": "~2.0.1",
-        "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.1",
-        "stringify-package": "^1.0.1",
-        "tar": "^4.4.13",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "ssri": "^8.0.1",
+        "tar": "^6.1.0",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
-        "uid-number": "0.0.6",
-        "umask": "~1.1.0",
-        "unique-filename": "^1.1.1",
-        "unpipe": "~1.0.0",
-        "update-notifier": "^2.5.0",
-        "uuid": "^3.3.3",
-        "validate-npm-package-license": "^3.0.4",
+        "treeverse": "^1.0.4",
         "validate-npm-package-name": "~3.0.0",
-        "which": "^1.3.1",
-        "worker-farm": "^1.7.0",
-        "write-file-atomic": "^2.4.3"
+        "which": "^2.0.2",
+        "write-file-atomic": "^3.0.3"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.5",
+        "@npmcli/arborist": {
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
+            "@npmcli/installed-package-contents": "^1.0.7",
+            "@npmcli/map-workspaces": "^1.0.2",
+            "@npmcli/metavuln-calculator": "^1.1.0",
+            "@npmcli/move-file": "^1.1.0",
+            "@npmcli/name-from-folder": "^1.0.1",
+            "@npmcli/node-gyp": "^1.0.1",
+            "@npmcli/run-script": "^1.8.2",
+            "bin-links": "^2.2.1",
+            "cacache": "^15.0.3",
+            "common-ancestor-path": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.1",
+            "json-stringify-nice": "^1.1.2",
+            "mkdirp-infer-owner": "^2.0.0",
+            "npm-install-checks": "^4.0.0",
+            "npm-package-arg": "^8.1.0",
+            "npm-pick-manifest": "^6.1.0",
+            "npm-registry-fetch": "^9.0.0",
+            "pacote": "^11.2.6",
+            "parse-conflict-json": "^1.1.1",
+            "promise-all-reject-late": "^1.0.0",
+            "promise-call-limit": "^1.0.1",
+            "read-package-json-fast": "^2.0.2",
+            "readdir-scoped-modules": "^1.1.0",
+            "semver": "^7.3.5",
+            "tar": "^6.1.0",
+            "treeverse": "^1.0.4",
+            "walk-up-path": "^1.0.0"
           }
+        },
+        "@npmcli/ci-detect": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/config": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ini": "^2.0.0",
+            "mkdirp-infer-owner": "^2.0.0",
+            "nopt": "^5.0.0",
+            "semver": "^7.3.4",
+            "walk-up-path": "^1.0.0"
+          }
+        },
+        "@npmcli/disparity-colors": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.3.0"
+          }
+        },
+        "@npmcli/git": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/promise-spawn": "^1.1.0",
+            "lru-cache": "^6.0.0",
+            "mkdirp": "^1.0.3",
+            "npm-pick-manifest": "^6.0.0",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^2.0.1",
+            "semver": "^7.3.2",
+            "unique-filename": "^1.1.1",
+            "which": "^2.0.2"
+          }
+        },
+        "@npmcli/installed-package-contents": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-bundled": "^1.1.1",
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "@npmcli/map-workspaces": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/name-from-folder": "^1.0.1",
+            "glob": "^7.1.6",
+            "minimatch": "^3.0.4",
+            "read-package-json-fast": "^2.0.1"
+          }
+        },
+        "@npmcli/metavuln-calculator": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cacache": "^15.0.5",
+            "pacote": "^11.1.11",
+            "semver": "^7.3.2"
+          }
+        },
+        "@npmcli/move-file": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mkdirp": "^1.0.4",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "@npmcli/name-from-folder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/node-gyp": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/promise-spawn": {
+          "version": "1.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "infer-owner": "^1.0.4"
+          }
+        },
+        "@npmcli/run-script": {
+          "version": "1.8.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/node-gyp": "^1.0.2",
+            "@npmcli/promise-spawn": "^1.3.2",
+            "infer-owner": "^1.0.4",
+            "node-gyp": "^7.1.0",
+            "read-package-json-fast": "^2.0.1"
+          }
+        },
+        "@tootallnate/once": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
         },
         "abbrev": {
           "version": "1.1.1",
@@ -15459,27 +15563,41 @@
           "dev": true
         },
         "agent-base": {
-          "version": "4.3.0",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "es6-promisify": "^5.0.0"
+            "debug": "4"
           }
         },
         "agentkeepalive": {
-          "version": "3.5.2",
+          "version": "4.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
+            "debug": "^4.1.0",
+            "depd": "^1.1.2",
             "humanize-ms": "^1.2.1"
           }
         },
-        "ansi-align": {
-          "version": "2.0.0",
+        "aggregate-error": {
+          "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^2.0.0"
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "ansi-regex": {
@@ -15488,11 +15606,11 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "3.2.1",
+          "version": "4.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "^2.0.1"
           }
         },
         "ansicolors": {
@@ -15516,36 +15634,12 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
           }
         },
         "asap": {
@@ -15577,7 +15671,7 @@
           "dev": true
         },
         "aws4": {
-          "version": "1.8.0",
+          "version": "1.11.0",
           "bundled": true,
           "dev": true
         },
@@ -15590,42 +15684,27 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "tweetnacl": "^0.14.3"
           }
         },
         "bin-links": {
-          "version": "1.1.8",
+          "version": "2.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.3",
-            "cmd-shim": "^3.0.0",
-            "gentle-fs": "^2.3.0",
-            "graceful-fs": "^4.1.15",
+            "cmd-shim": "^4.0.1",
+            "mkdirp": "^1.0.3",
             "npm-normalize-package-bin": "^1.0.0",
-            "write-file-atomic": "^2.3.0"
+            "read-cmd-shim": "^2.0.0",
+            "rimraf": "^3.0.0",
+            "write-file-atomic": "^3.0.3"
           }
         },
-        "bluebird": {
-          "version": "3.5.5",
+        "binary-extensions": {
+          "version": "2.2.0",
           "bundled": true,
           "dev": true
-        },
-        "boxen": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
-          }
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -15636,62 +15715,39 @@
             "concat-map": "0.0.1"
           }
         },
-        "buffer-from": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "builtins": {
           "version": "1.0.3",
           "bundled": true,
           "dev": true
         },
-        "byline": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "byte-size": {
-          "version": "5.0.1",
+          "version": "7.0.1",
           "bundled": true,
           "dev": true
         },
         "cacache": {
-          "version": "12.0.3",
+          "version": "15.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.5",
-            "chownr": "^1.1.1",
-            "figgy-pudding": "^3.5.1",
+            "@npmcli/move-file": "^1.0.1",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
             "glob": "^7.1.4",
-            "graceful-fs": "^4.1.15",
-            "infer-owner": "^1.0.3",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.1",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^1.0.3",
+            "p-map": "^4.0.0",
             "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.3",
-            "ssri": "^6.0.1",
-            "unique-filename": "^1.1.1",
-            "y18n": "^4.0.0"
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.1",
+            "tar": "^6.0.2",
+            "unique-filename": "^1.1.1"
           }
-        },
-        "call-limit": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "capture-stack-trace": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -15699,35 +15755,29 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.4.1",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
         "chownr": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "ci-info": {
           "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "cidr-regex": {
-          "version": "2.0.10",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip-regex": "^2.1.0"
+            "ip-regex": "^4.1.0"
           }
         },
-        "cli-boxes": {
-          "version": "1.0.0",
+        "clean-stack": {
+          "version": "2.2.0",
           "bundled": true,
           "dev": true
         },
@@ -15741,51 +15791,41 @@
           }
         },
         "cli-table3": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "colors": "^1.1.2",
             "object-assign": "^4.1.0",
-            "string-width": "^2.1.1"
-          }
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
+            "string-width": "^4.2.0"
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "4.1.0",
+              "version": "5.0.0",
               "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
-              "version": "2.0.0",
+              "version": "3.0.0",
               "bundled": true,
               "dev": true
             },
             "string-width": {
-              "version": "3.1.0",
+              "version": "4.2.2",
               "bundled": true,
               "dev": true,
               "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
               }
             },
             "strip-ansi": {
-              "version": "5.2.0",
+              "version": "6.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "^4.1.0"
+                "ansi-regex": "^5.0.0"
               }
             }
           }
@@ -15796,12 +15836,11 @@
           "dev": true
         },
         "cmd-shim": {
-          "version": "3.0.3",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "~0.5.0"
+            "mkdirp-infer-owner": "^2.0.0"
           }
         },
         "code-point-at": {
@@ -15810,20 +15849,20 @@
           "dev": true
         },
         "color-convert": {
-          "version": "1.9.1",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-name": "^1.1.1"
+            "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.3",
+          "version": "1.1.4",
           "bundled": true,
           "dev": true
         },
         "colors": {
-          "version": "1.3.3",
+          "version": "1.4.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -15838,151 +15877,30 @@
           }
         },
         "combined-stream": {
-          "version": "1.0.6",
+          "version": "1.0.8",
           "bundled": true,
           "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
         },
+        "common-ancestor-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
           "dev": true
-        },
-        "concat-stream": {
-          "version": "1.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "config-chain": {
-          "version": "1.1.12",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ini": "^1.3.4",
-            "proto-list": "~1.2.1"
-          }
-        },
-        "configstore": {
-          "version": "3.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dot-prop": "^4.2.1",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
           "dev": true
         },
-        "copy-concurrently": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^1.1.1",
-            "fs-write-stream-atomic": "^1.0.8",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "iferr": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "create-error-class": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "capture-stack-trace": "^1.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "4.1.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-              }
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "crypto-random-string": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "cyclist": {
-          "version": "0.2.2",
           "bundled": true,
           "dev": true
         },
@@ -15995,15 +15913,15 @@
           }
         },
         "debug": {
-          "version": "3.1.0",
+          "version": "4.3.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.2"
           },
           "dependencies": {
             "ms": {
-              "version": "2.0.0",
+              "version": "2.1.2",
               "bundled": true,
               "dev": true
             }
@@ -16014,35 +15932,12 @@
           "bundled": true,
           "dev": true
         },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "decode-uri-component": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true
-        },
         "defaults": {
           "version": "1.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "clone": "^1.0.2"
-          }
-        },
-        "define-properties": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-keys": "^1.0.12"
           }
         },
         "delayed-stream": {
@@ -16055,13 +15950,8 @@
           "bundled": true,
           "dev": true
         },
-        "detect-indent": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "detect-newline": {
-          "version": "2.1.0",
+        "depd": {
+          "version": "1.1.2",
           "bundled": true,
           "dev": true
         },
@@ -16074,173 +15964,43 @@
             "wrappy": "1"
           }
         },
-        "dot-prop": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
-        },
-        "dotenv": {
-          "version": "5.0.1",
+        "diff": {
+          "version": "5.0.0",
           "bundled": true,
           "dev": true
-        },
-        "duplexer3": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "duplexify": {
-          "version": "3.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0",
-            "stream-shift": "^1.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
         },
         "ecc-jsbn": {
           "version": "0.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.1.0"
           }
         },
-        "editor": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "emoji-regex": {
-          "version": "7.0.3",
+          "version": "8.0.0",
           "bundled": true,
           "dev": true
         },
         "encoding": {
-          "version": "0.1.12",
+          "version": "0.1.13",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "iconv-lite": "~0.4.13"
-          }
-        },
-        "end-of-stream": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "^1.4.0"
+            "iconv-lite": "^0.6.2"
           }
         },
         "env-paths": {
-          "version": "2.2.0",
+          "version": "2.2.1",
           "bundled": true,
           "dev": true
         },
         "err-code": {
-          "version": "1.1.2",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true
-        },
-        "errno": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prr": "~1.0.1"
-          }
-        },
-        "es-abstract": {
-          "version": "1.12.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.1.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.1",
-            "is-callable": "^1.1.3",
-            "is-regex": "^1.0.4"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "es6-promise": {
-          "version": "4.2.8",
-          "bundled": true,
-          "dev": true
-        },
-        "es6-promisify": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "es6-promise": "^4.0.3"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "execa": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
         },
         "extend": {
           "version": "3.0.2",
@@ -16252,53 +16012,15 @@
           "bundled": true,
           "dev": true
         },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true
+        },
         "fast-json-stable-stringify": {
-          "version": "2.0.0",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true
-        },
-        "figgy-pudding": {
-          "version": "3.5.1",
-          "bundled": true,
-          "dev": true
-        },
-        "find-npm-prefix": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "flush-write-stream": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.4"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -16306,115 +16028,21 @@
           "dev": true
         },
         "form-data": {
-          "version": "2.3.2",
+          "version": "2.3.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
-            "combined-stream": "1.0.6",
+            "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
         },
-        "from2": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
         "fs-minipass": {
-          "version": "1.2.7",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^2.6.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            }
-          }
-        },
-        "fs-vacuum": {
-          "version": "1.2.10",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "path-is-inside": "^1.0.1",
-            "rimraf": "^2.5.2"
-          }
-        },
-        "fs-write-stream-atomic": {
-          "version": "1.0.10",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
-          },
-          "dependencies": {
-            "iferr": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
+            "minipass": "^3.0.0"
           }
         },
         "fs.realpath": {
@@ -16447,6 +16075,14 @@
               "bundled": true,
               "dev": true
             },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
@@ -16457,54 +16093,6 @@
                 "strip-ansi": "^3.0.0"
               }
             }
-          }
-        },
-        "genfun": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "gentle-fs": {
-          "version": "2.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^1.1.2",
-            "chownr": "^1.1.2",
-            "cmd-shim": "^3.0.3",
-            "fs-vacuum": "^1.2.10",
-            "graceful-fs": "^4.1.11",
-            "iferr": "^0.1.5",
-            "infer-owner": "^1.0.4",
-            "mkdirp": "^0.5.1",
-            "path-is-inside": "^1.0.2",
-            "read-cmd-shim": "^1.0.1",
-            "slide": "^1.1.6"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "iferr": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
           }
         },
         "getpass": {
@@ -16528,41 +16116,8 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "global-dirs": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ini": "^1.3.4"
-          }
-        },
-        "got": {
-          "version": "6.7.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
         "graceful-fs": {
-          "version": "4.2.4",
+          "version": "4.2.6",
           "bundled": true,
           "dev": true
         },
@@ -16578,29 +16133,6 @@
           "requires": {
             "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "6.12.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-              }
-            },
-            "fast-deep-equal": {
-              "version": "3.1.3",
-              "bundled": true,
-              "dev": true
-            },
-            "json-schema-traverse": {
-              "version": "0.4.1",
-              "bundled": true,
-              "dev": true
-            }
           }
         },
         "has": {
@@ -16612,12 +16144,7 @@
           }
         },
         "has-flag": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "has-symbols": {
-          "version": "1.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -16627,22 +16154,26 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.8.8",
+          "version": "4.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "http-cache-semantics": {
-          "version": "3.8.1",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true
         },
         "http-proxy-agent": {
-          "version": "2.1.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "4",
-            "debug": "3.1.0"
+            "@tootallnate/once": "1",
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "http-signature": {
@@ -16656,12 +16187,12 @@
           }
         },
         "https-proxy-agent": {
-          "version": "2.2.4",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "humanize-ms": {
@@ -16673,17 +16204,13 @@
           }
         },
         "iconv-lite": {
-          "version": "0.4.23",
+          "version": "0.6.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
-        },
-        "iferr": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
         },
         "ignore-walk": {
           "version": "3.0.3",
@@ -16693,13 +16220,13 @@
             "minimatch": "^3.0.4"
           }
         },
-        "import-lazy": {
-          "version": "2.1.0",
+        "imurmurhash": {
+          "version": "0.1.4",
           "bundled": true,
           "dev": true
         },
-        "imurmurhash": {
-          "version": "0.1.4",
+        "indent-string": {
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -16723,22 +16250,22 @@
           "dev": true
         },
         "ini": {
-          "version": "1.3.8",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "init-package-json": {
-          "version": "1.10.3",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
-            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "npm-package-arg": "^8.1.0",
             "promzard": "^0.3.0",
             "read": "~1.0.1",
-            "read-package-json": "1 || 2",
-            "semver": "2.x || 3.x || 4 || 5",
-            "validate-npm-package-license": "^3.0.1",
+            "read-package-json": "^3.0.0",
+            "semver": "^7.3.2",
+            "validate-npm-package-license": "^3.0.4",
             "validate-npm-package-name": "^3.0.0"
           }
         },
@@ -16748,108 +16275,35 @@
           "dev": true
         },
         "ip-regex": {
-          "version": "2.1.0",
+          "version": "4.3.0",
           "bundled": true,
           "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "is-ci": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ci-info": "^1.5.0"
-          },
-          "dependencies": {
-            "ci-info": {
-              "version": "1.6.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
         },
         "is-cidr": {
-          "version": "3.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cidr-regex": "^2.0.10"
+            "cidr-regex": "^3.1.1"
           }
         },
-        "is-date-object": {
-          "version": "1.0.1",
+        "is-core-module": {
+          "version": "2.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
         },
         "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-installed-globally": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "global-dirs": "^0.1.0",
-            "is-path-inside": "^1.0.0"
-          }
-        },
-        "is-npm": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
-        "is-obj": {
+        "is-lambda": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true
-        },
-        "is-path-inside": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-is-inside": "^1.0.1"
-          }
-        },
-        "is-redirect": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has": "^1.0.1"
-          }
-        },
-        "is-retry-allowed": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-symbol": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.0"
-          }
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -16874,16 +16328,25 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
-        "json-parse-better-errors": {
-          "version": "1.0.2",
+        "json-parse-even-better-errors": {
+          "version": "2.3.1",
           "bundled": true,
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "json-stringify-nice": {
+          "version": "1.1.3",
           "bundled": true,
           "dev": true
         },
@@ -16908,347 +16371,165 @@
             "verror": "1.10.0"
           }
         },
-        "latest-version": {
+        "just-diff": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "just-diff-apply": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "leven": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "libnpmaccess": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "minipass": "^3.1.1",
+            "npm-package-arg": "^8.0.0",
+            "npm-registry-fetch": "^9.0.0"
+          }
+        },
+        "libnpmdiff": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/disparity-colors": "^1.0.1",
+            "@npmcli/installed-package-contents": "^1.0.7",
+            "binary-extensions": "^2.2.0",
+            "diff": "^5.0.0",
+            "minimatch": "^3.0.4",
+            "npm-package-arg": "^8.1.1",
+            "pacote": "^11.3.0",
+            "tar": "^6.1.0"
+          }
+        },
+        "libnpmfund": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/arborist": "^2.0.0"
+          }
+        },
+        "libnpmhook": {
+          "version": "6.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^9.0.0"
+          }
+        },
+        "libnpmorg": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^9.0.0"
+          }
+        },
+        "libnpmpack": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/run-script": "^1.8.3",
+            "npm-package-arg": "^8.1.0",
+            "pacote": "^11.2.6"
+          }
+        },
+        "libnpmpublish": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "normalize-package-data": "^3.0.0",
+            "npm-package-arg": "^8.1.0",
+            "npm-registry-fetch": "^9.0.0",
+            "semver": "^7.1.3",
+            "ssri": "^8.0.0"
+          }
+        },
+        "libnpmsearch": {
           "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "package-json": "^4.0.0"
+            "npm-registry-fetch": "^9.0.0"
           }
         },
-        "lazy-property": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "libcipm": {
-          "version": "4.0.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bin-links": "^1.1.2",
-            "bluebird": "^3.5.1",
-            "figgy-pudding": "^3.5.1",
-            "find-npm-prefix": "^1.0.2",
-            "graceful-fs": "^4.1.11",
-            "ini": "^1.3.5",
-            "lock-verify": "^2.1.0",
-            "mkdirp": "^0.5.1",
-            "npm-lifecycle": "^3.0.0",
-            "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.1.0",
-            "pacote": "^9.1.0",
-            "read-package-json": "^2.0.13",
-            "rimraf": "^2.6.2",
-            "worker-farm": "^1.6.0"
-          }
-        },
-        "libnpm": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bin-links": "^1.1.2",
-            "bluebird": "^3.5.3",
-            "find-npm-prefix": "^1.0.2",
-            "libnpmaccess": "^3.0.2",
-            "libnpmconfig": "^1.2.1",
-            "libnpmhook": "^5.0.3",
-            "libnpmorg": "^1.0.1",
-            "libnpmpublish": "^1.1.2",
-            "libnpmsearch": "^2.0.2",
-            "libnpmteam": "^1.0.2",
-            "lock-verify": "^2.0.2",
-            "npm-lifecycle": "^3.0.0",
-            "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.1.0",
-            "npm-profile": "^4.0.2",
-            "npm-registry-fetch": "^4.0.0",
-            "npmlog": "^4.1.2",
-            "pacote": "^9.5.3",
-            "read-package-json": "^2.0.13",
-            "stringify-package": "^1.0.0"
-          }
-        },
-        "libnpmaccess": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "get-stream": "^4.0.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-registry-fetch": "^4.0.0"
-          }
-        },
-        "libnpmconfig": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "figgy-pudding": "^3.5.1",
-            "find-up": "^3.0.0",
-            "ini": "^1.3.5"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "libnpmhook": {
-          "version": "5.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "figgy-pudding": "^3.4.1",
-            "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^4.0.0"
-          }
-        },
-        "libnpmorg": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "figgy-pudding": "^3.4.1",
-            "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^4.0.0"
-          }
-        },
-        "libnpmpublish": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "figgy-pudding": "^3.5.1",
-            "get-stream": "^4.0.0",
-            "lodash.clonedeep": "^4.5.0",
-            "normalize-package-data": "^2.4.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-registry-fetch": "^4.0.0",
-            "semver": "^5.5.1",
-            "ssri": "^6.0.1"
-          }
-        },
-        "libnpmsearch": {
+        "libnpmteam": {
           "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "^3.5.1",
-            "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^4.0.0"
-          }
-        },
-        "libnpmteam": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
             "aproba": "^2.0.0",
-            "figgy-pudding": "^3.4.1",
-            "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^4.0.0"
+            "npm-registry-fetch": "^9.0.0"
           }
         },
-        "libnpx": {
-          "version": "10.2.4",
+        "libnpmversion": {
+          "version": "1.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^14.2.3"
+            "@npmcli/git": "^2.0.6",
+            "@npmcli/run-script": "^1.8.3",
+            "json-parse-even-better-errors": "^2.3.1",
+            "semver": "^7.3.4",
+            "stringify-package": "^1.0.1"
           }
-        },
-        "lock-verify": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "npm-package-arg": "^6.1.0",
-            "semver": "^5.4.1"
-          }
-        },
-        "lockfile": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "lodash._baseindexof": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._baseuniq": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lodash._createset": "~4.0.0",
-            "lodash._root": "~3.0.0"
-          }
-        },
-        "lodash._bindcallback": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._cacheindexof": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._createcache": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lodash._getnative": "^3.0.0"
-          }
-        },
-        "lodash._createset": {
-          "version": "4.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._root": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.clonedeep": {
-          "version": "4.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.restparam": {
-          "version": "3.6.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.union": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.uniq": {
-          "version": "4.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.without": {
-          "version": "4.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lowercase-keys": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
         },
         "lru-cache": {
-          "version": "5.1.1",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "make-dir": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
+            "yallist": "^4.0.0"
           }
         },
         "make-fetch-happen": {
-          "version": "5.0.2",
+          "version": "8.0.14",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agentkeepalive": "^3.4.1",
-            "cacache": "^12.0.0",
-            "http-cache-semantics": "^3.8.1",
-            "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.3",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "node-fetch-npm": "^2.0.2",
-            "promise-retry": "^1.1.1",
-            "socks-proxy-agent": "^4.0.0",
-            "ssri": "^6.0.0"
+            "agentkeepalive": "^4.1.3",
+            "cacache": "^15.0.5",
+            "http-cache-semantics": "^4.1.0",
+            "http-proxy-agent": "^4.0.1",
+            "https-proxy-agent": "^5.0.0",
+            "is-lambda": "^1.0.1",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.3",
+            "minipass-collect": "^1.0.2",
+            "minipass-fetch": "^1.3.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "promise-retry": "^2.0.1",
+            "socks-proxy-agent": "^5.0.0",
+            "ssri": "^8.0.0"
           }
         },
-        "meant": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
         "mime-db": {
-          "version": "1.35.0",
+          "version": "1.46.0",
           "bundled": true,
           "dev": true
         },
         "mime-types": {
-          "version": "2.1.19",
+          "version": "2.1.29",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "~1.35.0"
+            "mime-db": "1.46.0"
           }
         },
         "minimatch": {
@@ -17259,157 +16540,142 @@
             "brace-expansion": "^1.1.7"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
+        "minipass": {
+          "version": "3.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
         },
-        "minizlib": {
+        "minipass-collect": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-fetch": {
           "version": "1.3.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^2.9.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            }
+            "encoding": "^0.1.12",
+            "minipass": "^3.1.0",
+            "minipass-sized": "^1.0.3",
+            "minizlib": "^2.0.0"
           }
         },
-        "mississippi": {
-          "version": "3.0.0",
+        "minipass-flush": {
+          "version": "1.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
+            "minipass": "^3.0.0"
           }
         },
-        "mkdirp": {
-          "version": "0.5.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.5",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "move-concurrently": {
+        "minipass-json-stream": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            }
+            "jsonparse": "^1.3.1",
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-pipeline": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-sized": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp-infer-owner": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "infer-owner": "^1.0.4",
+            "mkdirp": "^1.0.3"
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.3",
           "bundled": true,
           "dev": true
         },
         "mute-stream": {
-          "version": "0.0.7",
+          "version": "0.0.8",
           "bundled": true,
           "dev": true
         },
-        "node-fetch-npm": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "json-parse-better-errors": "^1.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        },
         "node-gyp": {
-          "version": "5.1.0",
+          "version": "7.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
-            "graceful-fs": "^4.2.2",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
+            "graceful-fs": "^4.2.3",
+            "nopt": "^5.0.0",
             "npmlog": "^4.1.2",
-            "request": "^2.88.0",
-            "rimraf": "^2.6.3",
-            "semver": "^5.7.1",
-            "tar": "^4.4.12",
-            "which": "^1.3.1"
+            "request": "^2.88.2",
+            "rimraf": "^3.0.2",
+            "semver": "^7.3.2",
+            "tar": "^6.0.2",
+            "which": "^2.0.2"
           }
         },
         "nopt": {
-          "version": "4.0.3",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1"
           }
         },
         "normalize-package-data": {
-          "version": "2.5.0",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
+            "hosted-git-info": "^4.0.1",
+            "resolve": "^1.20.0",
+            "semver": "^7.3.4",
             "validate-npm-package-license": "^3.0.1"
-          },
-          "dependencies": {
-            "resolve": {
-              "version": "1.10.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-parse": "^1.0.6"
-              }
-            }
           }
         },
         "npm-audit-report": {
-          "version": "1.3.3",
+          "version": "2.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cli-table3": "^0.5.0",
-            "console-control-strings": "^1.1.0"
+            "chalk": "^4.0.0"
           }
         },
         "npm-bundled": {
@@ -17420,38 +16686,13 @@
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
-        "npm-cache-filename": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
         "npm-install-checks": {
-          "version": "3.0.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "^2.3.0 || 3.x || 4 || 5"
+            "semver": "^7.1.1"
           }
-        },
-        "npm-lifecycle": {
-          "version": "3.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "byline": "^5.0.0",
-            "graceful-fs": "^4.1.15",
-            "node-gyp": "^5.0.2",
-            "resolve-from": "^4.0.0",
-            "slide": "^1.1.6",
-            "uid-number": "0.0.6",
-            "umask": "^1.1.0",
-            "which": "^1.3.1"
-          }
-        },
-        "npm-logical-tree": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
@@ -17459,73 +16700,58 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "6.1.1",
+          "version": "8.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.7.1",
-            "osenv": "^0.1.5",
-            "semver": "^5.6.0",
+            "hosted-git-info": "^4.0.1",
+            "semver": "^7.3.4",
             "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
-          "version": "1.4.8",
+          "version": "2.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1",
+            "glob": "^7.1.6",
+            "ignore-walk": "^3.0.3",
+            "npm-bundled": "^1.1.1",
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-pick-manifest": {
-          "version": "3.0.2",
+          "version": "6.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "^3.5.1",
-            "npm-package-arg": "^6.0.0",
-            "semver": "^5.4.1"
+            "npm-install-checks": "^4.0.0",
+            "npm-normalize-package-bin": "^1.0.1",
+            "npm-package-arg": "^8.1.2",
+            "semver": "^7.3.4"
           }
         },
         "npm-profile": {
-          "version": "4.0.4",
+          "version": "5.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.1.2 || 2",
-            "figgy-pudding": "^3.4.1",
-            "npm-registry-fetch": "^4.0.0"
+            "npm-registry-fetch": "^9.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "4.0.7",
+          "version": "9.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "JSONStream": "^1.3.4",
-            "bluebird": "^3.5.1",
-            "figgy-pudding": "^3.4.1",
-            "lru-cache": "^5.1.1",
-            "make-fetch-happen": "^5.0.0",
-            "npm-package-arg": "^6.1.0",
-            "safe-buffer": "^5.2.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.2.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
+            "@npmcli/ci-detect": "^1.0.0",
+            "lru-cache": "^6.0.0",
+            "make-fetch-happen": "^8.0.9",
+            "minipass": "^3.1.3",
+            "minipass-fetch": "^1.3.0",
+            "minipass-json-stream": "^1.0.1",
+            "minizlib": "^2.0.0",
+            "npm-package-arg": "^8.0.0"
           }
         },
         "npm-user-validate": {
@@ -17559,20 +16785,6 @@
           "bundled": true,
           "dev": true
         },
-        "object-keys": {
-          "version": "1.0.12",
-          "bundled": true,
-          "dev": true
-        },
-        "object.getownpropertydescriptors": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "es-abstract": "^1.5.1"
-          }
-        },
         "once": {
           "version": "1.4.0",
           "bundled": true,
@@ -17586,140 +16798,52 @@
           "bundled": true,
           "dev": true
         },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "osenv": {
-          "version": "0.1.5",
+        "p-map": {
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
+            "aggregate-error": "^3.0.0"
           }
         },
         "pacote": {
-          "version": "9.5.12",
+          "version": "11.3.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.3",
-            "cacache": "^12.0.2",
-            "chownr": "^1.1.2",
-            "figgy-pudding": "^3.5.1",
-            "get-stream": "^4.1.0",
-            "glob": "^7.1.3",
+            "@npmcli/git": "^2.0.1",
+            "@npmcli/installed-package-contents": "^1.0.6",
+            "@npmcli/promise-spawn": "^1.2.0",
+            "@npmcli/run-script": "^1.8.2",
+            "cacache": "^15.0.5",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.1.0",
             "infer-owner": "^1.0.4",
-            "lru-cache": "^5.1.1",
-            "make-fetch-happen": "^5.0.0",
-            "minimatch": "^3.0.4",
-            "minipass": "^2.3.5",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "normalize-package-data": "^2.4.0",
-            "npm-normalize-package-bin": "^1.0.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.12",
-            "npm-pick-manifest": "^3.0.0",
-            "npm-registry-fetch": "^4.0.0",
-            "osenv": "^0.1.5",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.1",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.2",
-            "semver": "^5.6.0",
-            "ssri": "^6.0.1",
-            "tar": "^4.4.10",
-            "unique-filename": "^1.1.1",
-            "which": "^1.3.1"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            }
+            "minipass": "^3.1.3",
+            "mkdirp": "^1.0.3",
+            "npm-package-arg": "^8.0.1",
+            "npm-packlist": "^2.1.4",
+            "npm-pick-manifest": "^6.0.0",
+            "npm-registry-fetch": "^9.0.0",
+            "promise-retry": "^2.0.1",
+            "read-package-json-fast": "^2.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.1",
+            "tar": "^6.1.0"
           }
         },
-        "parallel-transform": {
-          "version": "1.1.0",
+        "parse-conflict-json": {
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cyclist": "~0.2.2",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.1.5"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
+            "json-parse-even-better-errors": "^2.3.0",
+            "just-diff": "^3.0.1",
+            "just-diff-apply": "^3.0.0"
           }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
           "bundled": true,
           "dev": true
         },
@@ -17733,18 +16857,18 @@
           "bundled": true,
           "dev": true
         },
-        "pify": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "promise-all-reject-late": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "promise-call-limit": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true
         },
@@ -17754,19 +16878,12 @@
           "dev": true
         },
         "promise-retry": {
-          "version": "1.1.1",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "err-code": "^1.0.0",
-            "retry": "^0.10.0"
-          },
-          "dependencies": {
-            "retry": {
-              "version": "0.10.1",
-              "bundled": true,
-              "dev": true
-            }
+            "err-code": "^2.0.2",
+            "retry": "^0.12.0"
           }
         },
         "promzard": {
@@ -17777,66 +16894,13 @@
             "read": "1"
           }
         },
-        "proto-list": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true
-        },
-        "protoduck": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "genfun": "^5.0.0"
-          }
-        },
-        "prr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
         "psl": {
-          "version": "1.1.29",
+          "version": "1.8.0",
           "bundled": true,
           "dev": true
-        },
-        "pump": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "pumpify": {
-          "version": "1.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
-          },
-          "dependencies": {
-            "pump": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            }
-          }
         },
         "punycode": {
-          "version": "1.4.1",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true
         },
@@ -17850,32 +16914,6 @@
           "bundled": true,
           "dev": true
         },
-        "query-string": {
-          "version": "6.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "decode-uri-component": "^0.2.0",
-            "split-on-first": "^1.0.0",
-            "strict-uri-encode": "^2.0.0"
-          }
-        },
-        "qw": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          }
-        },
         "read": {
           "version": "1.0.7",
           "bundled": true,
@@ -17885,57 +16923,42 @@
           }
         },
         "read-cmd-shim": {
-          "version": "1.0.5",
+          "version": "2.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2"
-          }
-        },
-        "read-installed": {
-          "version": "4.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debuglog": "^1.0.1",
-            "graceful-fs": "^4.1.2",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "slide": "~1.1.3",
-            "util-extend": "^1.0.1"
-          }
+          "dev": true
         },
         "read-package-json": {
-          "version": "2.1.1",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
-            "graceful-fs": "^4.1.2",
-            "json-parse-better-errors": "^1.0.1",
-            "normalize-package-data": "^2.0.0",
+            "json-parse-even-better-errors": "^2.3.0",
+            "normalize-package-data": "^3.0.0",
             "npm-normalize-package-bin": "^1.0.0"
           }
         },
-        "read-package-tree": {
-          "version": "5.3.1",
+        "read-package-json-fast": {
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "util-promisify": "^2.1.0"
+            "json-parse-even-better-errors": "^2.3.0",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "readable-stream": {
-          "version": "3.6.0",
+          "version": "2.3.7",
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "readdir-scoped-modules": {
@@ -17949,25 +16972,8 @@
             "once": "^1.3.0"
           }
         },
-        "registry-auth-token": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "rc": "^1.0.1"
-          }
-        },
         "request": {
-          "version": "2.88.0",
+          "version": "2.88.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17978,7 +16984,7 @@
             "extend": "~3.0.2",
             "forever-agent": "~0.6.1",
             "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
+            "har-validator": "~5.1.3",
             "http-signature": "~1.2.0",
             "is-typedarray": "~1.0.0",
             "isstream": "~0.1.2",
@@ -17988,25 +16994,30 @@
             "performance-now": "^2.1.0",
             "qs": "~6.5.2",
             "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
+            "tough-cookie": "~2.5.0",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "tough-cookie": {
+              "version": "2.5.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+              }
+            }
           }
         },
-        "require-directory": {
-          "version": "2.1.1",
+        "resolve": {
+          "version": "1.20.0",
           "bundled": true,
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
         },
         "retry": {
           "version": "0.12.0",
@@ -18014,26 +17025,11 @@
           "dev": true
         },
         "rimraf": {
-          "version": "2.7.1",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "run-queue": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^1.1.1"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            }
           }
         },
         "safe-buffer": {
@@ -18047,16 +17043,11 @@
           "dev": true
         },
         "semver": {
-          "version": "5.7.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver-diff": {
-          "version": "2.1.0",
+          "version": "7.3.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "^5.0.3"
+            "lru-cache": "^6.0.0"
           }
         },
         "set-blocking": {
@@ -18064,34 +17055,8 @@
           "bundled": true,
           "dev": true
         },
-        "sha": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2"
-          }
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "slide": {
-          "version": "1.1.6",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true
         },
@@ -18101,81 +17066,26 @@
           "dev": true
         },
         "socks": {
-          "version": "2.3.3",
+          "version": "2.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip": "1.1.5",
+            "ip": "^1.1.5",
             "smart-buffer": "^4.1.0"
           }
         },
         "socks-proxy-agent": {
-          "version": "4.0.2",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "~4.2.1",
-            "socks": "~2.3.2"
-          },
-          "dependencies": {
-            "agent-base": {
-              "version": "4.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "es6-promisify": "^5.0.0"
-              }
-            }
-          }
-        },
-        "sorted-object": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "sorted-union-stream": {
-          "version": "2.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "from2": "^1.3.0",
-            "stream-iterate": "^1.1.0"
-          },
-          "dependencies": {
-            "from2": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~1.1.10"
-              }
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "1.1.14",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "bundled": true,
-              "dev": true
-            }
+            "agent-base": "6",
+            "debug": "4",
+            "socks": "^2.3.3"
           }
         },
         "spdx-correct": {
-          "version": "3.0.0",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -18184,12 +17094,12 @@
           }
         },
         "spdx-exceptions": {
-          "version": "2.1.0",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true
         },
         "spdx-expression-parse": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -18198,17 +17108,12 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "split-on-first": {
-          "version": "1.1.0",
+          "version": "3.0.7",
           "bundled": true,
           "dev": true
         },
         "sshpk": {
-          "version": "1.14.2",
+          "version": "1.16.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -18224,64 +17129,12 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
+          "version": "8.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "^3.5.1"
+            "minipass": "^3.1.1"
           }
-        },
-        "stream-each": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "stream-shift": "^1.0.0"
-          }
-        },
-        "stream-iterate": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "readable-stream": "^2.1.5",
-            "stream-shift": "^1.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "stream-shift": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "strict-uri-encode": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
@@ -18297,11 +17150,6 @@
               "bundled": true,
               "dev": true
             },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
@@ -18313,18 +17161,11 @@
           }
         },
         "string_decoder": {
-          "version": "1.3.0",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.2.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true
-            }
+            "safe-buffer": "~5.1.0"
           }
         },
         "stringify-package": {
@@ -18340,102 +17181,29 @@
             "ansi-regex": "^2.0.0"
           }
         },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "supports-color": {
-          "version": "5.4.0",
+          "version": "7.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         },
         "tar": {
-          "version": "4.4.13",
+          "version": "6.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            }
-          }
-        },
-        "term-size": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "execa": "^0.7.0"
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "through": {
-          "version": "2.3.8",
-          "bundled": true,
-          "dev": true
-        },
-        "through2": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "timed-out": {
-          "version": "4.0.1",
           "bundled": true,
           "dev": true
         },
@@ -18444,14 +17212,10 @@
           "bundled": true,
           "dev": true
         },
-        "tough-cookie": {
-          "version": "2.4.3",
+        "treeverse": {
+          "version": "1.0.4",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
+          "dev": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
@@ -18464,23 +17228,15 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
+          "dev": true
+        },
+        "typedarray-to-buffer": {
+          "version": "3.1.5",
+          "bundled": true,
           "dev": true,
-          "optional": true
-        },
-        "typedarray": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "umask": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "requires": {
+            "is-typedarray": "^1.0.0"
+          }
         },
         "unique-filename": {
           "version": "1.1.1",
@@ -18491,69 +17247,19 @@
           }
         },
         "unique-slug": {
-          "version": "2.0.0",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
           }
         },
-        "unique-string": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "crypto-random-string": "^1.0.0"
-          }
-        },
-        "unpipe": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "unzip-response": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "update-notifier": {
-          "version": "2.5.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
         "uri-js": {
-          "version": "4.4.0",
+          "version": "4.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "punycode": "^2.1.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prepend-http": "^1.0.1"
           }
         },
         "util-deprecate": {
@@ -18561,21 +17267,8 @@
           "bundled": true,
           "dev": true
         },
-        "util-extend": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "util-promisify": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object.getownpropertydescriptors": "^2.0.3"
-          }
-        },
         "uuid": {
-          "version": "3.3.3",
+          "version": "3.4.0",
           "bundled": true,
           "dev": true
         },
@@ -18606,6 +17299,11 @@
             "extsprintf": "^1.2.0"
           }
         },
+        "walk-up-path": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
         "wcwidth": {
           "version": "1.0.1",
           "bundled": true,
@@ -18615,92 +17313,19 @@
           }
         },
         "which": {
-          "version": "1.3.1",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
-        "which-module": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^1.0.2"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "widest-line": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1"
-          }
-        },
-        "worker-farm": {
-          "version": "1.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "errno": "~0.1.7"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            }
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -18709,131 +17334,20 @@
           "dev": true
         },
         "write-file-atomic": {
-          "version": "2.4.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
           "version": "3.0.3",
           "bundled": true,
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true,
           "dev": true
-        },
-        "yargs": {
-          "version": "14.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^15.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "find-up": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "15.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -22614,9 +21128,9 @@
       "dev": true
     },
     "tempy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.0.tgz",
-      "integrity": "sha512-eLXG5B1G0mRPHmgH2WydPl5v4jH35qEn3y/rA/aahKhIa91Pn119SsU7n7v/433gtT9ONzC8ISvNHIh2JSTm0w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
       "dev": true,
       "requires": {
         "del": "^6.0.0",
@@ -22696,9 +21210,9 @@
           }
         },
         "globby": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-          "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "axios": "0.21.1",
     "babel-eslint": "10.1.0",
     "buefy": "0.8.20",
-    "chart.js": "3.0.1",
+    "chart.js": "2.9.4",
     "compression-webpack-plugin": "6.1.1",
     "css-loader": "5.2.0",
     "dompurify": "2.2.7",


### PR DESCRIPTION
I also fixed some audit stuff regarding npm so the changes are a bit more than expected. 

According to https://github.com/apertureless/vue-chartjs/issues/695 chart.js v3 support is not yet added to vue-chartjs