### PR TITLE
fix(body): fix abbreviation. Fixes HELP-1666

### DIFF
--- a/src/views/core/bodies/Edit.vue
+++ b/src/views/core/bodies/Edit.vue
@@ -113,7 +113,7 @@
         <div class="field">
           <label class="label">Address</label>
           <div class="control">
-            <input class="input" type="text" required v-model="body.address" />
+            <input class="input" type="text" v-model="body.address" />
           </div>
           <p class="help is-danger" v-if="errors.address">{{ errors.address.join(', ')}}</p>
         </div>
@@ -200,7 +200,7 @@ export default {
     return {
       body: {
         name: '',
-        abbreviation: '',
+        abbreviation: null,
         description: '',
         task_description: '',
         id: null,


### PR DESCRIPTION
Address is not required anymore in core, I forgot to remove this in the previous PR.
Abbreviation must be unique in core, and so the validation failed. Now there is no data being put in the database anymore

Fixes part of HELP-1666