### PR TITLE
chore(menu): remove permission

### DIFF
--- a/src/menu.json
+++ b/src/menu.json
@@ -132,8 +132,7 @@
           },
           {
             "name": "oms.summeruniversity.boardview",
-            "label": "Board view",
-            "permissions": ["local:approve_members:summeruniversity"]
+            "label": "Board view"
           }
         ]
       },


### PR DESCRIPTION
Not sure why it works for global permissions, but not with local permissions. But it's the way it is, this is an okay fix for now.