### PR TITLE
fix(map): increase zoom

### DIFF
--- a/src/views/events/Edit.vue
+++ b/src/views/events/Edit.vue
@@ -621,7 +621,7 @@ export default {
         actions: null,
         style: credentials.MAPS_API_TOKEN,
         center: { lat: 50.8503396, lng: 4.3517103 },
-        zoom: 8
+        zoom: 3
       },
       eventTypes: constants.EVENT_TYPES_NAMES,
       file: null,

--- a/src/views/events/Single.vue
+++ b/src/views/events/Single.vue
@@ -283,7 +283,7 @@ export default {
         actions: null,
         style: credentials.MAPS_API_TOKEN,
         center: { lat: 50.8503396, lng: 4.3517103 },
-        zoom: 8
+        zoom: 3
       },
       isLoading: false,
       can: {

--- a/src/views/statutory/Edit.vue
+++ b/src/views/statutory/Edit.vue
@@ -419,7 +419,7 @@ export default {
         actions: null,
         style: credentials.MAPS_API_TOKEN,
         center: { lat: 50.8503396, lng: 4.3517103 },
-        zoom: 8
+        zoom: 3
       },
       newValue: '',
       autoComplete: {

--- a/src/views/statutory/Single.vue
+++ b/src/views/statutory/Single.vue
@@ -305,7 +305,7 @@ export default {
         actions: null,
         style: credentials.MAPS_API_TOKEN,
         center: { lat: 50.8503396, lng: 4.3517103 },
-        zoom: 8
+        zoom: 3
       },
       isLoading: false,
       can: {

--- a/src/views/summeruniversity/Edit.vue
+++ b/src/views/summeruniversity/Edit.vue
@@ -853,7 +853,7 @@ export default {
         actions: null,
         style: credentials.MAPS_API_TOKEN,
         center: { lat: 50.8503396, lng: 4.3517103 },
-        zoom: 8
+        zoom: 3
       },
       eventTypes: constants.SUMMERUNIVERSITY_TYPES_NAMES,
       paxConfirmations: constants.SUMMERUNIVERSITY_PAX_CONFIRMATIONS,

--- a/src/views/summeruniversity/EditSecond.vue
+++ b/src/views/summeruniversity/EditSecond.vue
@@ -494,7 +494,7 @@ export default {
         actions: null,
         style: credentials.MAPS_API_TOKEN,
         center: { lat: 50.8503396, lng: 4.3517103 },
-        zoom: 8
+        zoom: 3
       },
       eventTypes: constants.SUMMERUNIVERSITY_TYPES_NAMES,
       paxConfirmations: constants.SUMMERUNIVERSITY_PAX_CONFIRMATIONS,

--- a/src/views/summeruniversity/Single.vue
+++ b/src/views/summeruniversity/Single.vue
@@ -456,7 +456,7 @@ export default {
         actions: null,
         style: credentials.MAPS_API_TOKEN,
         center: { lat: 50.8503396, lng: 4.3517103 },
-        zoom: 8
+        zoom: 3
       },
       isLoading: false,
       can: {


### PR DESCRIPTION
By changing the zoom to 3 we do not load something very zoomed in which will take a lot of tiles if we fly across Europe. This should theoretically lower the amount of tile requests to MapTiler.