### PR TITLE
fix(statutory): add button to VotesAmounts from JC view

### DIFF
--- a/src/views/statutory/Juridical.vue
+++ b/src/views/statutory/Juridical.vue
@@ -12,10 +12,13 @@
             </div>
           </div>
 
-          <div class="control">
-            <button @click="exportDelegatesJc()" class="button is-primary">
-              Export all delegates for OMS JC
-            </button>
+          <div class="field is-grouped">
+            <div class="control">
+              <a @click="exportDelegatesJc()" class="button is-primary">Export all delegates for OMS JC</a>
+            </div>
+            <div class="control">
+              <router-link :to="{ name: 'oms.statutory.votes', params: { id: this.$route.params.id } }" class="button is-primary" >View amount of votes</router-link>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
I always forget that the VotesAmounts page is not reachable in MyAEGEE through clicking buttons. This fixes that and will prevent questions from JC where to find the page again