### PR TITLE
fix(statutory): prefill email and date of birth for candidates

### DIFF
--- a/src/views/statutory/EditCandidate.vue
+++ b/src/views/statutory/EditCandidate.vue
@@ -327,6 +327,7 @@ export default {
   mounted () {
     this.bodies = this.loginUser.bodies
       .filter(body => ['contact', 'contact antenna', 'antenna'].includes(body.type))
+
     if (!this.$route.params.candidate_id) {
       // Prefilling values
       this.candidate.first_name = this.loginUser.first_name

--- a/src/views/statutory/EditCandidate.vue
+++ b/src/views/statutory/EditCandidate.vue
@@ -327,14 +327,13 @@ export default {
   mounted () {
     this.bodies = this.loginUser.bodies
       .filter(body => ['contact', 'contact antenna', 'antenna'].includes(body.type))
-
     if (!this.$route.params.candidate_id) {
       // Prefilling values
       this.candidate.first_name = this.loginUser.first_name
       this.candidate.last_name = this.loginUser.last_name
-      this.candidate.email = this.loginUser.user.email
-      this.candidate.date_of_birth = this.loginUser.date_of_birth
-      this.candidate.member_since = moment(this.loginUser.user.inserted_at).format('YYYY-MM-DD')
+      this.candidate.email = this.loginUser.email
+      this.candidate.date_of_birth = moment(this.loginUser.date_of_birth).format('YYYY-MM-DD')
+      this.candidate.member_since = moment(this.loginUser.created_at).format('YYYY-MM-DD')
 
       if (this.bodies.length) {
         this.candidate.body_id = this.bodies[0].id


### PR DESCRIPTION
As mentioned by Vale privately.

Using `created_at` for `member_since` is not the nicest solution but people can still update it.