### PR TITLE
fix: add Hong Kongese to nationalities list

### DIFF
--- a/src/nationalities.json
+++ b/src/nationalities.json
@@ -76,6 +76,7 @@
    "Guyanese",
    "Haitian",
    "Herzegovinian",
+   "Hong Kongese",
    "Honduran",
    "Hungarian",
    "I-Kiribati",


### PR DESCRIPTION
As per request of a member, forwarded by SUCT