### PR TITLE
Update board view events

### DIFF
--- a/src/views/events/BoardView.vue
+++ b/src/views/events/BoardView.vue
@@ -32,6 +32,8 @@
           :data="applications"
           :row-class="row => calculateClassForApplication(row)"
           :loading="isLoading"
+          default-sort="updated_at"
+          default-sort-direction="desc"
           v-if="selectedBody && boardBodies.length > 0">
           <template slot-scope="props">
             <b-table-column field="updated_at" label="Date modified" sortable>

--- a/src/views/events/BoardView.vue
+++ b/src/views/events/BoardView.vue
@@ -53,9 +53,7 @@
             </b-table-column>
 
             <b-table-column field="board_comment" label="Board comment">
-              <div class="control">
-                <input class="input" v-model="props.row.board_comment" />
-              </div>
+              <textarea class="textarea" v-model="props.row.board_comment" />
             </b-table-column>
 
             <b-table-column field="status" label="Status" sortable>

--- a/src/views/summeruniversity/BoardView.vue
+++ b/src/views/summeruniversity/BoardView.vue
@@ -66,9 +66,7 @@
             </b-table-column>
 
             <b-table-column field="board_comment" label="Board comment">
-              <div class="control">
-                <input class="input" v-model="props.row.board_comment" />
-              </div>
+              <textarea class="textarea" v-model="props.row.board_comment" />
             </b-table-column>
 
             <b-table-column label="Save">

--- a/src/views/summeruniversity/BoardView.vue
+++ b/src/views/summeruniversity/BoardView.vue
@@ -32,6 +32,8 @@
           :data="applications"
           :row-class="row => calculateClassForApplication(row)"
           :loading="isLoading"
+          default-sort="updated_at"
+          default-sort-direction="desc"
           v-if="selectedBody && boardBodies.length > 0">
           <template slot-scope="props">
             <b-table-column field="updated_at" label="Date modified" sortable>


### PR DESCRIPTION
Change the board view of the events (both for "regular" events and SU's) to:
- Sort based on the "updated_at" column automatically, so board members can find new applications easier
- Have a textarea field instead of an input field for the board comment (makes it the same as for statutory)