### PR TITLE
fix(core): display notification email instead of email in user profile

### DIFF
--- a/src/views/core/members/Single.vue
+++ b/src/views/core/members/Single.vue
@@ -128,8 +128,8 @@
                   <td data-cy="superadmin">{{ (user.superadmin) ? 'Yes' : 'No' }}</td>
                 </tr>
                 <tr>
-                  <th>Email</th>
-                  <td><a :href="'mailto:' + user.email" data-cy="email">{{ user.email }}</a></td>
+                  <th>Notification email</th>
+                  <td><a :href="'mailto:' + user.email" data-cy="notification_email">{{ user.notification_email }}</a></td>
                 </tr>
                 <tr>
                   <th>GSuite account</th>
@@ -212,7 +212,7 @@ export default {
         date_of_birth: null,
         gender: null,
         phone: null,
-        email: null,
+        notification_email: null,
         active: null,
         superadmin: null,
         username: null


### PR DESCRIPTION
It is unclear which email is set as notification email in the frontend, this change improves this. Finding the non-GSuite email of the user is still possible for admins by going to the edit page of a profile (or by using the API).