### PR TITLE
ci: remove npm clean install override

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - node/install-packages:
-          override-ci-command: npm install --legacy-peer-deps
+      - node/install-packages
       - run: mkdir -p ~/reports
       - run: npx eslint --ext .js,.vue . --format junit --output-file ~/reports/eslint.xml
       - store_test_results:
@@ -100,8 +99,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.23
-      - node/install-packages:
-          override-ci-command: npm install --legacy-peer-deps
+      - node/install-packages
       - run: npx semantic-release
       - run: echo export PACKAGE_VERSION=$(node -p "require('./package.json').version") >> $BASH_ENV
       - run: docker build  --tag aegee/frontend:$PACKAGE_VERSION --tag aegee/frontend:latest -f docker/Dockerfile .


### PR DESCRIPTION
I figured out what is different between the build job and docker-build-and-push job. We installed through `npm install` in docker-build-and-push for semantic-release and don't remove that before copying the directory (including docker-build-and-push). We'll need to do this in other repos as well in the future and make sure that node_modules is not copied over to the docker build for docker-build-and-push. But that's something for in the monorepo and when we move to GitHub Actions.