### PR TITLE
fix(core): rename to Google Workspace and edit body gsuite_id and google_group

### DIFF
--- a/src/views/core/bodies/Edit.vue
+++ b/src/views/core/bodies/Edit.vue
@@ -108,6 +108,22 @@
         </div>
 
         <div class="field">
+          <label class="label">Google Workspace account</label>
+          <div class="control">
+            <input class="input" data-cy="gsuite_id" type="email" required :disabled="!can.editGsuite" v-model="body.gsuite_id" placeholder="Type the Google Workspace email of the body" />
+          </div>
+          <p class="help is-danger" v-if="errors.gsuite_id">{{ errors.gsuite_id.join(', ')}}</p>
+        </div>
+
+        <div class="field">
+          <label class="label">Google Group</label>
+          <div class="control">
+            <input class="input" data-cy="google_group" type="email" required :disabled="!can.editGsuite" v-model="body.google_group" placeholder="Type the Google Group of the body" />
+          </div>
+          <p class="help is-danger" v-if="errors.google_group">{{ errors.google_group.join(', ')}}</p>
+        </div>
+
+        <div class="field">
           <label class="label">Phone</label>
           <div class="control has-icons-left">
             <span class="icon is-small is-left"><font-awesome-icon icon="phone" /></span>
@@ -212,6 +228,8 @@ export default {
         id: null,
         code: null,
         email: null,
+        gsuite_id: null,
+        google_group: null,
         phone: null,
         address: null,
         postal_address: null,
@@ -226,7 +244,8 @@ export default {
         editAbbreviation: true,
         editCode: true,
         editShadowCircle: true,
-        editType: true
+        editType: true,
+        editGsuite: false
       },
       countries,
       autocompleteBody: '',
@@ -306,6 +325,7 @@ export default {
       this.can.editCode = editGlobalPermission
       this.can.editShadowCircle = editGlobalPermission
       this.can.editType = editGlobalPermission
+      this.can.editGsuite = editGlobalPermission
     }).catch((err) => {
       if (err.response.status === 404) {
         this.$root.showError('Body is not found')

--- a/src/views/core/bodies/Single.vue
+++ b/src/views/core/bodies/Single.vue
@@ -142,6 +142,16 @@
                   <td v-if="body.email"><a :href="'mailto:' + body.email">{{ body.email }}</a></td>
                   <td v-if="!body.email"><i>Not set.</i></td>
                 </tr>
+                <tr v-if="can.editGsuite">
+                  <th>Google Workspace account</th>
+                  <td v-if="body.gsuite_id"><a :href="'mailto:' + body.gsuite_id" data-cy="gsuite">{{ body.gsuite_id }}</a></td>
+                  <td v-if="!body.gsuite_id"><i>Not set.</i></td>
+                </tr>
+                <tr v-if="can.editGsuite">
+                  <th>Google Group</th>
+                  <td v-if="body.google_group"><a :href="'mailto:' + body.google_group" data-cy="google_group">{{ user.body.google_group }}</a></td>
+                  <td v-if="!body.google_group"><i>Not set.</i></td>
+                </tr>
                 <tr v-if="body.phone">
                   <th>Phone</th>
                   <td>{{ body.phone }}</td>
@@ -272,7 +282,8 @@ export default {
         manageBoards: false,
         updateBody: false,
         deleteBody: false,
-        addMembers: false
+        addMembers: false,
+        editGsuite: false
       }
     }
   },
@@ -460,6 +471,7 @@ export default {
           this.can.updateBody = this.permissions.some(permission => permission.combined.endsWith('update:body'))
           this.can.deleteBody = this.permissions.some(permission => permission.combined.endsWith('delete:body'))
           this.can.addMembers = this.permissions.some(permission => permission.combined.endsWith('add_member:body'))
+          this.can.editGsuite = this.permissions.some(permission => permission.combined.endsWith('global:update:body'))
 
           this.isLoading = false
         })

--- a/src/views/core/bodies/Single.vue
+++ b/src/views/core/bodies/Single.vue
@@ -149,7 +149,7 @@
                 </tr>
                 <tr v-if="can.editGsuite">
                   <th>Google Group</th>
-                  <td v-if="body.google_group"><a :href="'mailto:' + body.google_group" data-cy="google_group">{{ user.body.google_group }}</a></td>
+                  <td v-if="body.google_group"><a :href="'mailto:' + body.google_group" data-cy="google_group">{{ body.google_group }}</a></td>
                   <td v-if="!body.google_group"><i>Not set.</i></td>
                 </tr>
                 <tr v-if="body.phone">

--- a/src/views/core/members/Edit.vue
+++ b/src/views/core/members/Edit.vue
@@ -27,9 +27,9 @@
         </div>
 
         <div class="field">
-          <label class="label">GSuite account</label>
+          <label class="label">Google Workspace account</label>
           <div class="control">
-            <input class="input" data-cy="gsuite_id" type="email" required :disabled="!can.editGsuite" v-model="user.gsuite_id" placeholder="Type your GSuite account..." />
+            <input class="input" data-cy="gsuite_id" type="email" required :disabled="!can.editGsuite" v-model="user.gsuite_id" placeholder="Type the Google Workspace email of the user" />
           </div>
           <p class="help is-danger" v-if="errors.gsuite_id">{{ errors.gsuite_id.join(', ')}}</p>
         </div>

--- a/src/views/core/members/Single.vue
+++ b/src/views/core/members/Single.vue
@@ -132,7 +132,7 @@
                   <td><a :href="'mailto:' + user.email" data-cy="notification_email">{{ user.notification_email }}</a></td>
                 </tr>
                 <tr>
-                  <th>GSuite account</th>
+                  <th>Google Workspace account</th>
                   <td v-if="user.gsuite_id"><a :href="'mailto:' + user.gsuite_id" data-cy="gsuite">{{ user.gsuite_id }}</a></td>
                   <td v-if="!user.gsuite_id"><i>Not set.</i></td>
                 </tr>

--- a/src/views/events/Edit.vue
+++ b/src/views/events/Edit.vue
@@ -543,7 +543,7 @@
               You can take the template for the budget and the program here.
             </a></p>
             <p><i>
-              Note: in case you cannot see AEGEE templates at the link above, try switching to AEGEE GSuite account.
+              Note: in case you cannot see AEGEE templates at the link above, try switching to AEGEE Google Workspace account.
               In case you don't have one,
               <a href="https://oms-project.atlassian.net/wiki/spaces/HEL/pages/248348673/Requesting+a+Gsuite+account+for+yourself" target="blank">
                 here's how to request it

--- a/src/views/static/About.vue
+++ b/src/views/static/About.vue
@@ -120,8 +120,8 @@
             <a href="https://www.atlassian.com/software/confluence" target="_blank" rel="noopener noreferrer">
               <img src="/images/partners-logos/confluence.svg" alt="Confluence" />
             </a>
-            <a href="https://gsuite.google.com/" target="_blank" rel="noopener noreferrer">
-              <img src="/images/partners-logos/gsuite.svg" alt="GSuite" />
+            <a href="https://workspace.google.com/" target="_blank" rel="noopener noreferrer">
+              <img src="/images/partners-logos/gsuite.svg" alt="Google Workspace" />
             </a>
             <a href="https://www.elastic.co/" target="_blank" rel="noopener noreferrer">
               <img src="/images/partners-logos/elastic.svg" alt="Elastic" />
@@ -171,7 +171,7 @@
 
               <tr>
                 <td><a href="https://github.com/AEGEE/gsuite-wrapper">gsuite-wrapper</a></td>
-                <td>Integrates GSuite with MyAEGEE.</td>
+                <td>Integrates Google Workspace (formerly GSuite) with MyAEGEE.</td>
               </tr>
             </tbody>
           </table>

--- a/src/views/summeruniversity/Edit.vue
+++ b/src/views/summeruniversity/Edit.vue
@@ -736,7 +736,7 @@
               You can take the templates for the budget and programme here.
             </a></p>
             <p><i>
-              Note: in case you cannot see AEGEE templates at the link above, try switching to AEGEE GSuite account.
+              Note: in case you cannot see AEGEE templates at the link above, try switching to AEGEE Google Workspace account.
               In case you don't have one,
               <a href="https://oms-project.atlassian.net/wiki/spaces/HEL/pages/248348673/Requesting+a+Gsuite+account+for+yourself" target="blank">
                 here's how to request it

--- a/src/views/summeruniversity/EditSecond.vue
+++ b/src/views/summeruniversity/EditSecond.vue
@@ -419,7 +419,7 @@
               You can take the templates for the budget and programme here.
             </a></p>
             <p><i>
-              Note: in case you cannot see AEGEE templates at the link above, try switching to AEGEE GSuite account.
+              Note: in case you cannot see AEGEE templates at the link above, try switching to AEGEE Google Workspace account.
               In case you don't have one,
               <a href="https://oms-project.atlassian.net/wiki/spaces/HEL/pages/248348673/Requesting+a+Gsuite+account+for+yourself" target="blank">
                 here's how to request it


### PR DESCRIPTION
It's about time we used the proper name for Google Workspace instead of keeping it as GSuite. I did keep a reference to it for the name of gsuite-wrapper.

Also this incorporates the new field in the body. A PR in core is linked to this