### PR TITLE
fix: removed unnecessary paddings in the mobile breakpoint

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -342,3 +342,19 @@ h1, h2, h3, h4, h5, h6 {
 	  transition: opacity .15s;
 	}
 }
+
+// Responsive fixes.
+@include mobile {
+  .app-main > .container {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  
+  .card  {
+    margin-bottom: 2em;
+  }
+  
+  .box  {
+    border-radius: 0;
+  }
+}


### PR DESCRIPTION
Our intranet it's not very space efficient on mobile version, makins difficult to use especially with low resolution smartphones.

With this PR I started to take in account just the global container padding and some minor touches. 

Will follow events list overhaul (style and how many info to be shown) in later PRs.