### PR TITLE
fix: increase the mapbox popup width

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -80,8 +80,14 @@ h1, h2, h3, h4, h5, h6 {
 
 /* for MapBox popups */
 .mapbox-popup-custom {
-	max-width: 250px;
+	max-width: 500px;
+	max-height: 280px;
+	overflow-y: auto;
 	font-size: medium;
+	
+	@include mobile {
+		max-width: 250px;
+	}
 }
 
 .bold {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -80,7 +80,7 @@ h1, h2, h3, h4, h5, h6 {
 
 /* for MapBox popups */
 .mapbox-popup-custom {
-	width: 80px;
+	max-width: 250px;
 	font-size: medium;
 }
 


### PR DESCRIPTION
The actual width of the popup in the event map is only 80px, not enough to display the name of certain cities in one line and super inadequate for the city description.

My proposal is to change the CSS from `width: 80px` to `max-width: 500px` for desktop and `max-width 250px` for mobile. This can keep a small popup with smaller content as just the city name but expand for larger content. However this not completly fix the usability of the popup. For this reason I fixed the maximum height of the popop to 280px (calculated from the mobile map height) and added scrollable text in case of long text content.

As-is:
![immagine](https://github.com/AEGEE/frontend/assets/632339/0a6e046c-7d38-4b3e-a08a-e6be49dbf58b)

After the patch (mobile):
![immagine](https://github.com/AEGEE/frontend/assets/632339/8f248b24-f89b-4d70-b484-bfaa1893f6a0)

After the path (desktop):
![immagine](https://github.com/AEGEE/frontend/assets/632339/58b4c55c-5e08-45b1-90c3-257cdb91ede8)

