### PR TITLE
fix: add global permissions to board view on menu

### DIFF
--- a/src/menu.json
+++ b/src/menu.json
@@ -86,7 +86,7 @@
           {
             "name": "oms.events.boardview",
             "label": "Board view",
-            "permissions": ["local:approve_members:events"]
+            "permissions": ["global:see_boardview:events"]
           }
         ]
       },
@@ -135,7 +135,7 @@
           {
             "name": "oms.summeruniversity.boardview",
             "label": "Board view",
-            "permissions": ["local:approve_members:summeruniversity"]
+            "permissions": ["global:see_boardview:summeruniversity"]
           }
         ]
       },


### PR DESCRIPTION
The permissions that are used in the menu are global only, from https://github.com/AEGEE/core/blob/cfbd2a1b307564f3e295425e210d8b854c68de67/lib/permissions-manager.js#L133-L139